### PR TITLE
✨ feat: useClickOutside hook 구현

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -13,7 +13,7 @@ export function useClickOutside<T extends HTMLElement = HTMLElement>(
     return () => {
       document.removeEventListener('click', handleOutsideClick);
     };
-  });
+  }, [ref, handler]);
 
   return;
 }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,3 @@
+export function useClickOutside() {
+  return;
+}

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect } from 'react';
 
 export function useClickOutside<T extends HTMLElement = HTMLElement>(
   /** HTMLElement가 아니라 ref 객체 */
-  ref: RefObject<T>,
+  ref: RefObject<T | null>,
   /** react의 MouseEvent가 아니라 DOM 기본 MouseEvent */
   handler: (e: MouseEvent) => void,
 ) {

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,7 +1,9 @@
 import { RefObject, useEffect } from 'react';
 
 export function useClickOutside<T extends HTMLElement = HTMLElement>(
+  /** HTMLElement가 아니라 ref 객체 */
   ref: RefObject<T>,
+  /** react의 MouseEvent가 아니라 DOM 기본 MouseEvent */
   handler: (e: MouseEvent) => void,
 ) {
   useEffect(() => {

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,3 +1,19 @@
-export function useClickOutside() {
+import { RefObject, useEffect } from 'react';
+
+export function useClickOutside<T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  handler: (e: MouseEvent) => void,
+) {
+  useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) handler(e);
+    };
+
+    document.addEventListener('click', handleOutsideClick);
+    return () => {
+      document.removeEventListener('click', handleOutsideClick);
+    };
+  });
+
   return;
 }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -16,6 +16,4 @@ export function useClickOutside<T extends HTMLElement = HTMLElement>(
       document.removeEventListener('click', handleOutsideClick);
     };
   }, [ref, handler]);
-
-  return;
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

요소의 외부 click event handler를 추가하는 useClickOutside custom hook을 구현했습니다.

## 📝 상세 내용

- `ref`에는 ref 객체를 그대로 넣습니다.
- `handler`에는 click event handler를 넣습니다.

## 🔗 관련 이슈

Resolves: #31 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항

- `ref` parameter에 `null`을 허용한 이유는 ref 객체는 처음 선언될 때 기본값을 `null`이어서 `null`을 뺄 경우 type 오류가 발생합니다.
- 주석에도 적었지만 event handler의 event는 **React의 MouseEvent가 아니라 기본 (DOM) MouseEvent**입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new capability for detecting clicks outside a specified element, enabling improved handling of user interactions such as closing popups or dropdowns when clicking elsewhere on the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->