### PR TITLE
🐛 fix: 테일윈드 커스텀 변수명 변경 `text -> txt`

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,82 +26,82 @@
 }
 
 @layer components {
-  .text-11_M {
+  .txt-11_M {
     @apply text-[10px] font-medium;
   }
-  .text-11_B {
+  .txt-11_B {
     @apply text-[10px] font-bold;
   }
 
-  .text-12_M {
+  .txt-12_M {
     @apply text-[12px] font-medium;
   }
-  .text-12_B {
+  .txt-12_B {
     @apply text-[12px] font-bold;
   }
 
-  .text-13_M {
+  .txt-13_M {
     @apply text-[13px] font-medium;
   }
-  .text-13_B {
+  .txt-13_B {
     @apply text-[13px] font-bold;
   }
 
-  .text-14_M {
+  .txt-14_M {
     @apply text-[14px] font-medium;
   }
-  .text-14_B {
+  .txt-14_B {
     @apply text-[14px] font-bold;
   }
 
-  .text-16_M {
+  .txt-16_M {
     @apply text-[16px] font-medium;
   }
-  .text-16_B {
+  .txt-16_B {
     @apply text-[16px] font-bold;
   }
 
-  .text-18_M {
+  .txt-18_M {
     @apply text-[18px] font-medium;
   }
-  .text-18_B {
+  .txt-18_B {
     @apply text-[18px] font-bold;
   }
 
-  .text-20_M {
+  .txt-20_M {
     @apply text-[20px] font-medium;
   }
-  .text-20_B {
+  .txt-20_B {
     @apply text-[20px] font-bold;
   }
 
-  .text-24_M {
+  .txt-24_M {
     @apply text-[24px] font-medium;
   }
-  .text-24_B {
+  .txt-24_B {
     @apply text-[24px] font-bold;
   }
 
-  .text-32_M {
+  .txt-32_M {
     @apply text-[32px] font-medium;
   }
-  .text-32_B {
+  .txt-32_B {
     @apply text-[32px] font-bold;
   }
 
-  .text-14_body_M {
+  .txt-14_body_M {
     @apply text-[14px]/[180%] font-medium;
   }
 
-  .text-16_body_M {
+  .txt-16_body_M {
     @apply text-[16px]/[180%] font-medium;
   }
 
-  .text-18_body_B {
+  .txt-18_body_B {
     @apply text-[18px]/[140%] font-bold;
   }
 
-  .text-20_body_B {
+  .txt-20_body_B {
     @apply text-[20px]/[160%] font-bold;
   }
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
지현님이 구현해주신 cn 함수에 twMerge가 포함되어 있는데,
다인님이 만들어두신 글씨크기 변수의 네이밍이 text-로 시작되어
다른 스타일과 중복된다고 판단되어 적용이 안됩니다.

`<div className = {cn('text-32-B text-gray-300')}>1 2 3 4 5</div>` 에서 원래대로라면 text-32_B 와 text-gray-300 이 둘 다 적용되어야 하지만 현재 **text**-32_B 와 **text**-gray-300이 모두 **text-** 로 시작되어 중복된다고 판단되어, twMerge가 text-gray-300이 text-32_B를 덮어씌워 text-gray-300 만 적용합니다.

이를 해결할 수 있는 방법은 저희가 작성한 스타일 변수의 네이밍을 text가 아닌 다른 걸로 변경하면 됩니다.
이해하기 쉽게 txt로 변경했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
`text-16_B` 를 `txt-16_B`로 변경하는 식으로 모두 변경했습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #34 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항

#34 이슈 확인하시면 이해하기 편하실겁니다~!

**혹시나 기존에 text-12_M 같은 변수를 사용하신 분이나 사용하고 계신 분이 있다면 txt-12_M 이런식으로 수정해주셔야 합니다!!**
