### PR TITLE
🐛 fix: globals.css 내 스타일 변수 선언 방식 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,85 +25,109 @@
   --breakpoint-md: 744px;
 }
 
-@layer components {
-  .txt-11_M {
-    @apply text-[10px] font-medium;
-  }
-  .txt-11_B {
-    @apply text-[10px] font-bold;
-  }
+@utility txt-11_M {
+  font-size: 10px;
+  font-weight: 500;
+}
+@utility txt-11_B {
+  font-size: 10px;
+  font-weight: 700;
+}
 
-  .txt-12_M {
-    @apply text-[12px] font-medium;
-  }
-  .txt-12_B {
-    @apply text-[12px] font-bold;
-  }
+@utility txt-12_M {
+  font-size: 12px;
+  font-weight: 500;
+}
+@utility txt-12_B {
+  font-size: 12px;
+  font-weight: 700;
+}
 
-  .txt-13_M {
-    @apply text-[13px] font-medium;
-  }
-  .txt-13_B {
-    @apply text-[13px] font-bold;
-  }
+@utility txt-13_M {
+  font-size: 13px;
+  font-weight: 500;
+}
+@utility txt-13_B {
+  font-size: 13px;
+  font-weight: 700;
+}
 
-  .txt-14_M {
-    @apply text-[14px] font-medium;
-  }
-  .txt-14_B {
-    @apply text-[14px] font-bold;
-  }
+@utility txt-14_M {
+  font-size: 14px;
+  font-weight: 500;
+}
+@utility txt-14_B {
+  font-size: 14px;
+  font-weight: 700;
+}
 
-  .txt-16_M {
-    @apply text-[16px] font-medium;
-  }
-  .txt-16_B {
-    @apply text-[16px] font-bold;
-  }
+@utility txt-16_M {
+  font-size: 16px;
+  font-weight: 500;
+}
+@utility txt-16_B {
+  font-size: 16px;
+  font-weight: 700;
+}
 
-  .txt-18_M {
-    @apply text-[18px] font-medium;
-  }
-  .txt-18_B {
-    @apply text-[18px] font-bold;
-  }
+@utility txt-18_M {
+  font-size: 18px;
+  font-weight: 500;
+}
+@utility txt-18_B {
+  font-size: 18px;
+  font-weight: 700;
+}
 
-  .txt-20_M {
-    @apply text-[20px] font-medium;
-  }
-  .txt-20_B {
-    @apply text-[20px] font-bold;
-  }
+@utility txt-20_M {
+  font-size: 20px;
+  font-weight: 500;
+}
+@utility txt-20_B {
+  font-size: 20px;
+  font-weight: 700;
+}
 
-  .txt-24_M {
-    @apply text-[24px] font-medium;
-  }
-  .txt-24_B {
-    @apply text-[24px] font-bold;
-  }
+@utility txt-24_M {
+  font-size: 24px;
+  font-weight: 500;
+}
+@utility txt-24_B {
+  font-size: 24px;
+  font-weight: 700;
+}
 
-  .txt-32_M {
-    @apply text-[32px] font-medium;
-  }
-  .txt-32_B {
-    @apply text-[32px] font-bold;
-  }
+@utility txt-32_M {
+  font-size: 32px;
+  font-weight: 500;
+}
+@utility txt-32_B {
+  font-size: 32px;
+  font-weight: 700;
+}
 
-  .txt-14_body_M {
-    @apply text-[14px]/[180%] font-medium;
-  }
+@utility txt-14_body_M {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 180%;
+}
 
-  .txt-16_body_M {
-    @apply text-[16px]/[180%] font-medium;
-  }
+@utility txt-16_body_M {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 180%;
+}
 
-  .txt-18_body_B {
-    @apply text-[18px]/[140%] font-bold;
-  }
+@utility txt-18_body_B {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 140%;
+}
 
-  .txt-20_body_B {
-    @apply text-[20px]/[160%] font-bold;
-  }
+@utility txt-20_body_B {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 160%;
 }
 
 @layer base {


### PR DESCRIPTION
## 📌 변경 사항 개요

현재 선언 방식이 반응형 적용이 안되던 문제를 해결하기 위해 @utility를 활용해서 선언하는 방식으로 변경했습니다.

## 📝 상세 내용
기존 방식
```css
@layer components {
    .txt-12_M {
        @apply text-[12px] font-medium
    }
}
```

업데이트된 방식
```css
@utility txt-12_M {
  font-size: 12px;
  font-weight: 500;
}
```

변수 선언 방식을 변경한거라, 변수명은 바뀌지 않았습니다.
따라서 기존 작성한 코드에서 따로 변경하실 필요 없습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #47 

## 🖼️ 스크린샷(선택사항)

`<div className='txt-32_B md:txt-20_M lg:txt-13_B'>hihihihi</div>;` 를 기준으로 실험한 영상입니다. 반응형이 잘 작동합니다.

https://github.com/user-attachments/assets/c4f4dee8-8103-4754-917b-012520238ae6

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated text utility classes to use explicit CSS properties instead of Tailwind's utility application, ensuring consistent font sizes, weights, and line heights across the app. No visual or functional changes for end-users.
* **Chores**
  * Removed unused icon entries to streamline the icon set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->