### PR TITLE
🐛 fix: IconMap에서 눈모양 아이콘 제거

### DIFF
--- a/src/constants/iconMap.ts
+++ b/src/constants/iconMap.ts
@@ -1,6 +1,4 @@
 const ICON_MAP = {
-  AlarmActive: () => import('@/assets/icons/alarm_active.svg'),
-  AlarmInActive: () => import('@/assets/icons/alarm_inactive.svg'),
   ArrowLeft: () => import('@/assets/icons/arrow_left.svg'),
   ArrowRight: () => import('@/assets/icons/arrow_right.svg'),
   Art: () => import('@/assets/icons/art.svg'),


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
Icon 컴포넌트 내에서 사용할 변수 목록 중 눈모양 아이콘을 제거했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
색상이 변경될 수 있는 아이콘의 경우 Icon 컴포넌트로 분리하여 사용하도록 구현하였고
해당 컴포넌트를 사용할 때 필요없는 아이콘까지 불러올 경우를 대비하여 동적 import 로 필요한 아이콘만 불러오도록 했습니다.
허나, 눈모양 아이콘의 경우 동적 import로 불러올 경우 중간에 suspense의 fallback컴포넌트가 보이는 문제로 깜빡이는 것처럼 보이는 문제가 발생하였습니다.
따라서, 눈모양 아이콘은 굳이 색이 변화할 일이 없다고 판단하여 Icon 컴포넌트를 사용하지 않고 직접 import 하는 방식으로 변경했습니다.

footer의 facebook이나 instagram 등의 아이콘들도 색상이 변할 일이 없긴 한데, 추후에 다크모드나 ui 개선 과정에서 색상이 변할수도 있다고 판단하여 icon map에 넣어두긴 했으나, 가능할지는 잘 모르겠네요... 그래도 일단 넣어두겠습니다~!

추후에 또 이런 현상이 발생한다면 바로 말씀 주세요! 정 안되면 그냥 동적 import를 포기하는 방법도 있습니다 ㅎ..

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #50 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed "AlarmActive," "AlarmInActive," "EyeOff," and "EyeOn" icons from the available icon set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->