### PR TITLE
✨ feat : 예약 내역 관련 api 구현

### DIFF
--- a/src/app/mypage/reserves/page.tsx
+++ b/src/app/mypage/reserves/page.tsx
@@ -1,3 +1,3 @@
-export default function page() {
+export default async function page() {
   return <div>예약 내역 페이지입니다</div>;
 }

--- a/src/app/mypage/reserves/page.tsx
+++ b/src/app/mypage/reserves/page.tsx
@@ -1,3 +1,3 @@
-export default async function page() {
+export default function page() {
   return <div>예약 내역 페이지입니다</div>;
 }

--- a/src/libs/MyReservations.ts
+++ b/src/libs/MyReservations.ts
@@ -98,10 +98,8 @@ export interface ReviewBody {
 
 export const postReservationReview = async (
   reservationId: number,
-  body: ReviewBody,
+  { rating, content }: ReviewBody,
 ): Promise<MyReservation> => {
-  const { rating, content } = body;
-
   // rating 유효성 검사
   const isInteger = Number.isInteger(rating);
   const inRange = rating >= 1 && rating <= 5;
@@ -117,7 +115,7 @@ export const postReservationReview = async (
   try {
     const response = await api.post(
       `/my-reservations/${reservationId}/reviews`,
-      body,
+      { rating, content },
     );
     return response.data;
   } catch (error: unknown) {

--- a/src/libs/MyReservations.ts
+++ b/src/libs/MyReservations.ts
@@ -63,9 +63,9 @@ export const getMyReservations = async (
 
 export const patchReservationStatus = async (
   reservationId: number,
-  reservationUserId?: number,
-  currentStatus?: string,
-  currentUserId?: number,
+  reservationUserId: number,
+  currentStatus: string,
+  currentUserId: number,
 ): Promise<MyReservation> => {
   if (currentUserId !== reservationUserId) {
     throw new Error('본인의 예약만 취소할 수 있습니다.');

--- a/src/libs/MyReservations.ts
+++ b/src/libs/MyReservations.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 import {
+  MyReservation,
   MyReserves,
-  Reservation,
   ReservationStatus,
 } from '@/types/api/ReserveType';
 
@@ -53,10 +53,10 @@ export const getMyReservations = async (
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
-      const message = error.response?.data.message ?? '알 수 없는 오류';
+      const message =
+        error.response?.data.message ?? '예약 정보를 가져오는 데 실패했습니다';
       throw new Error(message);
     }
-    console.error('예약 정보 조회 실패:', error);
     throw new Error('예약 정보를 가져오는 데 실패했습니다');
   }
 };
@@ -66,7 +66,7 @@ export const patchReservationStatus = async (
   reservationUserId?: number,
   currentStatus?: string,
   currentUserId?: number,
-): Promise<Reservation> => {
+): Promise<MyReservation> => {
   if (currentUserId !== reservationUserId) {
     throw new Error('본인의 예약만 취소할 수 있습니다.');
   }
@@ -82,7 +82,8 @@ export const patchReservationStatus = async (
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
-      const message = error.response?.data.message ?? '알 수 없는 오류';
+      const message =
+        error.response?.data.message ?? '예약을 취소하는 것을 실패했습니다';
       throw new Error(message);
     }
 
@@ -90,11 +91,17 @@ export const patchReservationStatus = async (
   }
 };
 
+export interface ReviewBody {
+  rating: number;
+  content: string;
+}
+
 export const postReservationReview = async (
   reservationId: number,
-  rating: number,
-  content: string,
-): Promise<Reservation> => {
+  body: ReviewBody,
+): Promise<MyReservation> => {
+  const { rating, content } = body;
+
   // rating 유효성 검사
   const isInteger = Number.isInteger(rating);
   const inRange = rating >= 1 && rating <= 5;
@@ -103,18 +110,20 @@ export const postReservationReview = async (
     throw new Error('rating은 1~5 사이 정수로 입력해주세요.');
   }
 
+  if (typeof content !== 'string') {
+    throw new Error('content는 문자열로 입력해주세요.');
+  }
+
   try {
     const response = await api.post(
       `/my-reservations/${reservationId}/reviews`,
-      {
-        rating,
-        content,
-      },
+      body,
     );
     return response.data;
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
-      const message = error.response?.data.message ?? '알 수 없는 오류';
+      const message =
+        error.response?.data.message ?? '리뷰 작성을 실패 했습니다';
       throw new Error(message);
     }
 

--- a/src/libs/MyReservations.ts
+++ b/src/libs/MyReservations.ts
@@ -98,9 +98,10 @@ export interface ReviewBody {
 
 export const postReservationReview = async (
   reservationId: number,
-  { rating, content }: ReviewBody,
+  body: ReviewBody,
 ): Promise<MyReservation> => {
   // rating 유효성 검사
+  const { rating, content } = body;
   const isInteger = Number.isInteger(rating);
   const inRange = rating >= 1 && rating <= 5;
 
@@ -115,7 +116,7 @@ export const postReservationReview = async (
   try {
     const response = await api.post(
       `/my-reservations/${reservationId}/reviews`,
-      { rating, content },
+      { body },
     );
     return response.data;
   } catch (error: unknown) {

--- a/src/libs/Reserves.ts
+++ b/src/libs/Reserves.ts
@@ -1,17 +1,19 @@
 import axios from 'axios';
 
-import { MyReserves, Reservation } from '@/types/api/ReserveType';
+import {
+  MyReserves,
+  Reservation,
+  ReservationStatus,
+} from '@/types/api/ReserveType';
 
 import api from './textAxios';
 const reservationStatusList = [
   'pending',
   'confirmed',
   'declined',
-  'cancelled',
+  'canceled',
   'completed',
 ] as const;
-
-type ReservationStatus = (typeof reservationStatusList)[number];
 
 function isReservationStatus(value: unknown): value is ReservationStatus {
   return (
@@ -31,7 +33,7 @@ export const getMyReservations = async (
     params.cursor = cursorId;
   }
   if (size !== undefined) {
-    if (size < 1) {
+    if (!Number.isInteger(size) || size < 1) {
       throw new Error('size는 1 이상의 정수여야 합니다.');
     }
     params.size = size;
@@ -39,7 +41,7 @@ export const getMyReservations = async (
   if (status !== undefined) {
     if (!isReservationStatus(status)) {
       throw new Error(
-        'status는 pending, confirmed, completed, declined, cancelled 중 하나로 입력해주세요.',
+        'status는 pending, confirmed, completed, declined, canceled 중 하나로 입력해주세요.',
       );
     }
 

--- a/src/libs/Reserves.ts
+++ b/src/libs/Reserves.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { MyReserves } from '@/types/api/ReserveType';
+import { MyReserves, Reservation } from '@/types/api/ReserveType';
 
 import api from './textAxios';
 const reservationStatusList = [
@@ -25,25 +25,24 @@ export const getMyReservations = async (
   size?: number,
   status?: string,
 ): Promise<MyReserves> => {
-  if (status !== undefined && !isReservationStatus(status)) {
-    throw new Error(
-      'status는 pending, confirmed, completed, declined, cancelled 중 하나로 입력해주세요.',
-    );
-  }
-
-  if (size !== undefined && size < 1) {
-    throw new Error('size는 1 이상의 정수여야 합니다.');
-  }
-
   const params: Record<string, string | number | boolean> = {};
 
   if (cursorId !== undefined) {
     params.cursor = cursorId;
   }
   if (size !== undefined) {
+    if (size < 1) {
+      throw new Error('size는 1 이상의 정수여야 합니다.');
+    }
     params.size = size;
   }
   if (status !== undefined) {
+    if (!isReservationStatus(status)) {
+      throw new Error(
+        'status는 pending, confirmed, completed, declined, cancelled 중 하나로 입력해주세요.',
+      );
+    }
+
     params.status = status;
   }
 
@@ -51,10 +50,42 @@ export const getMyReservations = async (
     const response = await api.get('/my-reservations', { params });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 401) {
-      throw new Error('unauthorized');
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        throw new Error('unauthorized');
+      }
     }
     console.error('예약 정보 조회 실패:', error);
     throw new Error('예약 정보를 가져오는 데 실패했습니다');
+  }
+};
+
+export const patchReservationStatus = async (
+  reservationId: number,
+  reservationUserId?: number,
+  currentStatus?: string,
+  currentUserId?: number,
+): Promise<Reservation> => {
+  if (currentUserId !== reservationUserId) {
+    throw new Error('본인의 예약만 취소할 수 있습니다.');
+  }
+
+  if (currentStatus !== 'pending') {
+    throw new Error('예약 취소는 예약 신청 상태에서만 가능합니다.');
+  }
+  try {
+    const response = await api.patch(`/my-reservations/${reservationId}`, {
+      status: 'canceled',
+    });
+
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        throw new Error('unauthorized');
+      }
+    }
+    console.error('예약 취소 실패:', error);
+    throw new Error('예약을 취소하는 것을 실패했습니다');
   }
 };

--- a/src/libs/Reserves.ts
+++ b/src/libs/Reserves.ts
@@ -1,7 +1,8 @@
+import axios from 'axios';
+
 import { MyReserves } from '@/types/api/ReserveType';
 
 import api from './textAxios';
-
 const reservationStatusList = [
   'pending',
   'confirmed',
@@ -50,6 +51,9 @@ export const getMyReservations = async (
     const response = await api.get('/my-reservations', { params });
     return response.data;
   } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      throw new Error('unauthorized');
+    }
     console.error('예약 정보 조회 실패:', error);
     throw new Error('예약 정보를 가져오는 데 실패했습니다');
   }

--- a/src/libs/Reserves.ts
+++ b/src/libs/Reserves.ts
@@ -51,9 +51,8 @@ export const getMyReservations = async (
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
-      if (error.response?.status === 401) {
-        throw new Error('unauthorized');
-      }
+      const message = error.response?.data.message ?? '알 수 없는 오류';
+      throw new Error(message);
     }
     console.error('예약 정보 조회 실패:', error);
     throw new Error('예약 정보를 가져오는 데 실패했습니다');
@@ -81,11 +80,42 @@ export const patchReservationStatus = async (
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
-      if (error.response?.status === 401) {
-        throw new Error('unauthorized');
-      }
+      const message = error.response?.data.message ?? '알 수 없는 오류';
+      throw new Error(message);
     }
-    console.error('예약 취소 실패:', error);
+
     throw new Error('예약을 취소하는 것을 실패했습니다');
+  }
+};
+
+export const postReservationReview = async (
+  reservationId: number,
+  rating: number,
+  content: string,
+): Promise<Reservation> => {
+  // rating 유효성 검사
+  const isInteger = Number.isInteger(rating);
+  const inRange = rating >= 1 && rating <= 5;
+
+  if (!isInteger || !inRange) {
+    throw new Error('rating은 1~5 사이 정수로 입력해주세요.');
+  }
+
+  try {
+    const response = await api.post(
+      `/my-reservations/${reservationId}/reviews`,
+      {
+        rating,
+        content,
+      },
+    );
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data.message ?? '알 수 없는 오류';
+      throw new Error(message);
+    }
+
+    throw new Error('리뷰 작성을 실패 했습니다');
   }
 };

--- a/src/libs/Reserves.ts
+++ b/src/libs/Reserves.ts
@@ -1,0 +1,56 @@
+import { MyReserves } from '@/types/api/ReserveType';
+
+import api from './textAxios';
+
+const reservationStatusList = [
+  'pending',
+  'confirmed',
+  'declined',
+  'cancelled',
+  'completed',
+] as const;
+
+type ReservationStatus = (typeof reservationStatusList)[number];
+
+function isReservationStatus(value: unknown): value is ReservationStatus {
+  return (
+    typeof value === 'string' &&
+    reservationStatusList.includes(value as ReservationStatus)
+  );
+}
+
+export const getMyReservations = async (
+  cursorId?: number,
+  size?: number,
+  status?: string,
+): Promise<MyReserves> => {
+  if (status !== undefined && !isReservationStatus(status)) {
+    throw new Error(
+      'status는 pending, confirmed, completed, declined, cancelled 중 하나로 입력해주세요.',
+    );
+  }
+
+  if (size !== undefined && size < 1) {
+    throw new Error('size는 1 이상의 정수여야 합니다.');
+  }
+
+  const params: Record<string, string | number | boolean> = {};
+
+  if (cursorId !== undefined) {
+    params.cursor = cursorId;
+  }
+  if (size !== undefined) {
+    params.size = size;
+  }
+  if (status !== undefined) {
+    params.status = status;
+  }
+
+  try {
+    const response = await api.get('/my-reservations', { params });
+    return response.data;
+  } catch (error) {
+    console.error('예약 정보 조회 실패:', error);
+    throw new Error('예약 정보를 가져오는 데 실패했습니다');
+  }
+};

--- a/src/types/api/ReserveType.ts
+++ b/src/types/api/ReserveType.ts
@@ -2,7 +2,7 @@ export type ReservationStatus =
   | 'pending'
   | 'confirmed'
   | 'declined'
-  | 'cancelled'
+  | 'canceled'
   | 'completed';
 
 export interface MyReserves {
@@ -13,7 +13,7 @@ export interface MyReserves {
 
 export interface Reservation {
   id: number;
-  teamId: number;
+  teamId: string;
   userId: number;
   scheduleId: number;
   status: ReservationStatus;
@@ -25,7 +25,8 @@ export interface Reservation {
   endTime: string; // hh:mm
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
-  activity: Activity;
+  activity?: Activity;
+  activityId?: number;
 }
 
 export interface Activity {

--- a/src/types/api/ReserveType.ts
+++ b/src/types/api/ReserveType.ts
@@ -8,10 +8,10 @@ export type ReservationStatus =
 export interface MyReserves {
   cursorId: number | null;
   totalCount: number;
-  reservations: Reservation[];
+  reservations: MyReservation[];
 }
 
-export interface Reservation {
+export interface MyReservation {
   id: number;
   teamId: string;
   userId: number;

--- a/src/types/api/ReserveType.ts
+++ b/src/types/api/ReserveType.ts
@@ -1,0 +1,35 @@
+export type ReservationStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'declined'
+  | 'cancelled'
+  | 'completed';
+
+export interface MyReserves {
+  cursorId: number | null;
+  totalCount: number;
+  reservations: Reservation[];
+}
+
+export interface Reservation {
+  id: number;
+  teamId: number;
+  userId: number;
+  scheduleId: number;
+  status: ReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string; // yyyy-mm-dd
+  startTime: string; // hh:mm
+  endTime: string; // hh:mm
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+  activity: Activity;
+}
+
+export interface Activity {
+  bannerImageUrl: string | null;
+  title: string;
+  id: number;
+}

--- a/src/types/api/ReserveType.ts
+++ b/src/types/api/ReserveType.ts
@@ -15,18 +15,21 @@ export interface Reservation {
   id: number;
   teamId: string;
   userId: number;
-  scheduleId: number;
-  status: ReservationStatus;
-  reviewSubmitted: boolean;
-  totalPrice: number;
-  headCount: number;
-  date: string; // yyyy-mm-dd
-  startTime: string; // hh:mm
-  endTime: string; // hh:mm
+  scheduleId?: number;
+  activityId?: number;
+  status?: ReservationStatus;
+  reviewSubmitted?: boolean;
+  totalPrice?: number;
+  headCount?: number;
+  date?: string; // yyyy-mm-dd
+  startTime?: string; // hh:mm
+  endTime?: string; // hh:mm
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
+  deletedAt?: string; // ISO 8601
   activity?: Activity;
-  activityId?: number;
+  rating?: number;
+  content?: string;
 }
 
 export interface Activity {


### PR DESCRIPTION
## 📌 변경 사항 개요

예약 내역 조회, 예약 취소, 체험 후기 등록 API 호출 로직을 구현하고, 서버에서 내려오는 에러 메시지를 클라이언트에서 그대로 처리하도록 리팩토링했습니다.

---

## 📝 상세 내용

* **예약 내역 조회 (`getMyReservations`) API 구현**

  * `cursorId`, `size`, `status`를 파라미터로 받아 서버에 요청
  * `size`는 1 이상의 정수로 제한, `status`는 사전 정의된 상태값만 허용하도록 검증
  * 서버에서 반환된 데이터를 `MyReserves` 타입으로 반환
  * 에러 발생 시 서버 메시지를 우선적으로 클라이언트에 전달하고, 없으면 기본 에러 메시지를 던지도록 처리

* **예약 취소 (`patchReservationStatus`) API 구현**

  * 예약 ID, 예약자 ID, 현재 예약 상태, 요청자 ID를 받아 검증 후 취소 요청 수행
  * 본인이 아닌 예약 취소 시도나, 예약 상태가 'pending'이 아닐 경우 클라이언트에서 에러 발생
  * 서버 에러 메시지를 그대로 사용하며, 기본 메시지로 안전망 설정

* **체험 후기 등록 (`postReservationReview`) API 구현**

  * 예약 ID, 평점(rating), 후기 내용(content) 전달
  * 평점은 1\~5 사이의 정수인지 클라이언트에서 유효성 검사 수행
  * 서버에서 내려오는 에러 메시지를 그대로 사용하도록 리팩토링

* **에러 처리 로직 개선**

  * 기존에는 HTTP 상태 코드별로 에러 메시지를 분기 처리했으나,
    서버에서 일관된 에러 메시지를 반환하는 것으로 확인되어,
    `error.response?.data.message` 값을 그대로 클라이언트 에러 메시지로 사용하도록 변경
  * 이로 인해 코드가 간결해지고 유지보수가 쉬워졌으며, 사용자에게도 일관된 메시지 제공 가능
  * 서버 메시지가 없거나 알 수 없는 에러가 발생할 경우 대비해 기본 메시지(`'알 수 없는 오류'`)를 던지도록 처리

---

## 🔗 관련 이슈

Resolves: #51 

---

## 🖼️ 스크린샷(선택사항)

- 내 예약 조회 테스트
<img width="1206" height="899" alt="image" src="https://github.com/user-attachments/assets/29b38b10-0f8c-4af1-8045-6ce4333f0b53" />
<img width="1184" height="807" alt="image" src="https://github.com/user-attachments/assets/96531c19-4b12-47ce-ab06-cb557ca0aaae" />
<img width="1032" height="874" alt="image" src="https://github.com/user-attachments/assets/165372d0-a679-4563-bbda-020f5dbe84fc" />

- 내 예약 취소 테스트 (실패 경우 사진을 까먹었네요😅)
<img width="523" height="432" alt="image" src="https://github.com/user-attachments/assets/bc3e7009-e601-487f-b070-294319423ff8" />

- 내 예약 리뷰 테스트 
<img width="958" height="387" alt="image" src="https://github.com/user-attachments/assets/1c47328e-d484-4054-83d2-4b593f0c5429" />
<img width="957" height="319" alt="image" src="https://github.com/user-attachments/assets/8dba6fbc-3d7e-4694-97bf-5f2826db8abf" />
<img width="954" height="357" alt="image" src="https://github.com/user-attachments/assets/df16f067-10bb-4b0a-8f7a-1cd660978d5b" />
<img width="954" height="357" alt="image" src="https://github.com/user-attachments/assets/df16f067-10bb-4b0a-8f7a-1cd660978d5b" />

---

## 💡 참고 사항

* 서버 API에서 반환하는 에러 메시지를 그대로 클라이언트에서 사용하기 때문에, 별도의 상세 에러 분기 처리 코드를 최소화했습니다.
* 스웨거 상에 있으나 반환 되지 않는 에러만 따로 추가하였습니다
* 이로 인해 서버와 클라이언트 간 메시지 일관성을 유지할 수 있으며, 클라이언트 코드가 더 간결해졌습니다.
* 평점(rating)과 같은 입력값에 대해서는 클라이언트에서 사전 검증을 수행하여 불필요한 API 호출을 방지하고 있습니다.
* api import는 다인님 세팅 머지 되면 바로 수정하겠습니다! 
* Activity 타입은 나중에 Activity api와 type 구현하신 분의 껄로  수정하겠습니다 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to view their reservations with pagination and status filtering.
  * Enabled users to cancel their own reservations when eligible.
  * Introduced functionality for users to submit reviews for completed reservations.

* **Bug Fixes**
  * Improved error handling for reservation-related actions, providing clearer feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->