### PR TITLE
🐛 fix: Gnb Icon 변경

### DIFF
--- a/src/components/common/Gnb.tsx
+++ b/src/components/common/Gnb.tsx
@@ -5,11 +5,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
+import AlarmActive from '@/assets/icons/alarm_active.svg';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { cn } from '@/utils/cn';
 
 import DropDown from './DropDown';
-import Icon from './Icon';
 import NotificationPanel from './NotificationPanel';
 
 interface TemporaryProps {
@@ -67,12 +67,11 @@ export default function Gnb({ user }: TemporaryProps) {
           <>
             <div className='relative'>
               <button type='button' onClick={() => setIsOpen((prev) => !prev)}>
-                <Icon
+                <AlarmActive
                   className={cn(
                     'size-24',
                     isOpen ? 'text-primary-500' : 'text-gray-600',
                   )}
-                  icon='AlarmActive'
                 />
               </button>
               <NotificationPanel


### PR DESCRIPTION
Resolves: #86

## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
Gnb Icon을 수정했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
이전 pr에서 `Icon` component에서 Alarm을 삭제했는데 여전히 `Icon`에서 Alarm을 import 하고 있어 수정했습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
Resolves: #86
Ref: #52 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항

Lazy Loading 때문에 Icon에서 삭제하고 직접 svg 파일을 import 하는데 이래서는 lazy loading의 장점을 잘 모르겠습니다...?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 알람 아이콘이 SVG 컴포넌트로 직접 렌더링되어 아이콘 표시가 더 선명해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->