### PR TITLE
✨ feat: TopBanner 컴포넌트 구현

### DIFF
--- a/src/app/_components/TopBanner.tsx
+++ b/src/app/_components/TopBanner.tsx
@@ -26,7 +26,7 @@ export default function TopBanner({
       </div>
 
       <div className='absolute right-0 bottom-36 left-0 flex flex-col items-center justify-end gap-8 text-white md:bottom-76 md:gap-14 lg:bottom-101 lg:gap-19'>
-        <h1 className='txt-18_B md:txt-24_B lg:txt-32_B'>{title}</h1>
+        <h2 className='txt-18_B md:txt-24_B lg:txt-32_B'>{title}</h2>
         <p className='txt-14_M md:txt-16_B lg:txt-18_B'>{subtitle}</p>
       </div>
     </section>

--- a/src/app/_components/TopBanner.tsx
+++ b/src/app/_components/TopBanner.tsx
@@ -17,8 +17,9 @@ export default function TopBanner({
         <Image
           fill
           priority
-          alt={title}
+          alt=''
           className='object-cover'
+          sizes='(min-width: 1024px) 1120px, (min-width: 768px) 684px, 327px'
           src={imageUrl}
         />
         <div className='absolute inset-0 bg-gradient-to-b from-[rgba(0,0,0,0.15)] to-[rgba(0,0,0,0.5)]' />

--- a/src/app/_components/TopBanner.tsx
+++ b/src/app/_components/TopBanner.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+
+type TopBannerProps = {
+  imageUrl: string;
+  title: string;
+  subtitle: string;
+};
+
+export default function TopBanner({
+  imageUrl,
+  title,
+  subtitle,
+}: TopBannerProps) {
+  return (
+    <section className='relative w-full overflow-hidden rounded-[12px] shadow-[0_4px_24px_0_rgba(156,180,202,0.20)] md:rounded-[18px] lg:rounded-[24px]'>
+      <div className='relative aspect-[327/181] md:aspect-[684/375] lg:aspect-[1120/500]'>
+        <Image
+          fill
+          priority
+          alt={title}
+          className='object-cover'
+          src={imageUrl}
+        />
+      </div>
+
+      <div className='absolute right-0 bottom-36 left-0 flex flex-col items-center justify-end gap-8 text-white md:bottom-76 md:gap-14 lg:bottom-101 lg:gap-19'>
+        <h1 className='txt-18_B md:txt-24_B lg:txt-32_B'>{title}</h1>
+        <p className='txt-14_M md:txt-16_B lg:txt-18_B'>{subtitle}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/TopBanner.tsx
+++ b/src/app/_components/TopBanner.tsx
@@ -12,7 +12,7 @@ export default function TopBanner({
   subtitle,
 }: TopBannerProps) {
   return (
-    <section className='relative w-full overflow-hidden rounded-[12px] shadow-[0_4px_24px_0_rgba(156,180,202,0.20)] md:rounded-[18px] lg:rounded-[24px]'>
+    <section className='card-shadow relative w-full overflow-hidden rounded-[12px] md:rounded-[18px] lg:rounded-[24px]'>
       <div className='relative aspect-[327/181] md:aspect-[684/375] lg:aspect-[1120/500]'>
         <Image
           fill

--- a/src/app/_components/TopBanner.tsx
+++ b/src/app/_components/TopBanner.tsx
@@ -21,6 +21,7 @@ export default function TopBanner({
           className='object-cover'
           src={imageUrl}
         />
+        <div className='absolute inset-0 bg-gradient-to-b from-[rgba(0,0,0,0.15)] to-[rgba(0,0,0,0.5)]' />
       </div>
 
       <div className='absolute right-0 bottom-36 left-0 flex flex-col items-center justify-end gap-8 text-white md:bottom-76 md:gap-14 lg:bottom-101 lg:gap-19'>


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
메인 페이지 최상단에 위치하는 큰 이미지 섹션인 TopBanner 컴포넌트를 구현했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- 메인 페이지의 TopBanner 컴포넌트 구현
- image와 title, subtitle을 props로 받아 사용

### 🙇‍♂️🙇‍♂️ 논의 사항
프로젝트 요구사항에 아래처럼 적혀있습니다.

**메인 페이지 배너는 프론트단에서 하드코딩합니다(이미지는 자유)**

혹시 배너로 추천하실만한 이미지나 문구 있으신가요~??
## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #137 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
<img width="555" height="369" alt="image" src="https://github.com/user-attachments/assets/c58ab802-11d7-49ab-beb7-c3351e17797e" />

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 새로운 반응형 상단 배너 컴포넌트가 추가되어, 이미지, 제목, 부제목을 표시할 수 있습니다.  
  * 배경 이미지와 그라데이션 오버레이, 텍스트 정렬 및 스타일이 다양한 화면 크기에 맞게 자동으로 조정됩니다.  
  * 배너에 라운드 처리와 그림자 효과가 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->