### PR TITLE
✨ feat: Input textarea scrollbar 디자인

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -66,7 +66,6 @@ const FOCUS_STYLE =
   'focus:border-primary-500 focus:border-[1.5px] focus:px-18.5 focus:py-14.5';
 
 export default function Input({
-  id,
   className = '',
   label,
   errorMessage,
@@ -77,22 +76,20 @@ export default function Input({
 
     switch (props.type) {
       case 'dropdown':
-        return (
-          <DropdownInput className={`${COMMON_STYLE}`} id={id} {...props} />
-        );
+        return <DropdownInput className={`${COMMON_STYLE}`} {...props} />;
       case 'textarea':
-        return <TextareaInput className={className} id={id} {...props} />;
+        return <TextareaInput className={className} {...props} />;
       case 'password':
-        return <PasswordInput className={className} id={id} {...props} />;
+        return <PasswordInput className={className} {...props} />;
       default:
-        return <input className={className} id={id} {...props} />;
+        return <input className={className} {...props} />;
     }
   };
 
   return (
     <div className={'flex flex-col gap-10 ' + className}>
       {label && (
-        <label className='txt-16_M leading-19 text-gray-950' htmlFor={id}>
+        <label className='txt-16_M leading-19 text-gray-950' htmlFor={props.id}>
           {label}
         </label>
       )}
@@ -109,7 +106,6 @@ export default function Input({
 }
 
 function DropdownInput({
-  id,
   className,
   type,
   onClick,
@@ -134,13 +130,12 @@ function DropdownInput({
       <input
         ref={ref}
         className={`${className} ${value ? 'text-gray-950' : 'text-gray-400'} text-start`}
-        id={id}
         type='button'
         value={value ?? placeholder ?? ''}
         onClick={handleClick}
         {...props}
       />
-      <label className='absolute top-15 right-20' htmlFor={id}>
+      <label className='absolute top-15 right-20' htmlFor={props.id}>
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
       </label>
       {isOpen && (

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -170,11 +170,20 @@ function DropdownInput({
 
 function TextareaInput({ className, height, ...props }: TextareaProps) {
   return (
-    <textarea
-      className={`${className} resize-none`}
-      style={{ height }}
-      {...props}
-    />
+    <label className={cn(className, 'px-[16px]')} style={{ height }}>
+      <textarea
+        className={cn(
+          'block h-full resize-none outline-none',
+          '[&::-webkit-scrollbar]:w-3',
+          '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-200',
+          '[&::-webkit-scrollbar-button]:hidden',
+        )}
+        style={{
+          scrollbarGutter: 'stable both-edges',
+        }}
+        {...props}
+      />
+    </label>
   );
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -81,14 +81,7 @@ export default function Input({
           <DropdownInput className={`${COMMON_STYLE}`} id={id} {...props} />
         );
       case 'textarea':
-        return (
-          <textarea
-            className={`${className} resize-none`}
-            id={id}
-            style={{ height: props.height }}
-            {...props}
-          />
-        );
+        return <TextareaInput className={className} id={id} {...props} />;
       case 'password':
         return <PasswordInput className={className} id={id} {...props} />;
       default:
@@ -177,6 +170,16 @@ function DropdownInput({
         </div>
       )}
     </>
+  );
+}
+
+function TextareaInput({ className, height, ...props }: TextareaProps) {
+  return (
+    <textarea
+      className={`${className} resize-none`}
+      style={{ height }}
+      {...props}
+    />
   );
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -169,8 +169,18 @@ function DropdownInput({
 }
 
 function TextareaInput({ className, height, ...props }: TextareaProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
   return (
-    <label className={cn(className, 'px-[16px]')} style={{ height }}>
+    <label
+      className={cn(
+        className,
+        isFocused
+          ? 'border-primary-500 border-[1.5px] px-[15.5px] py-[14.5px]'
+          : 'px-[16px]',
+      )}
+      style={{ height }}
+    >
       <textarea
         className={cn(
           'block h-full resize-none outline-none',
@@ -181,6 +191,8 @@ function TextareaInput({ className, height, ...props }: TextareaProps) {
         style={{
           scrollbarGutter: 'stable both-edges',
         }}
+        onBlur={() => setIsFocused(false)}
+        onFocus={() => setIsFocused(true)}
         {...props}
       />
     </label>


### PR DESCRIPTION
## 📌 변경 사항 개요

Input type=textarea 에 대해서 scrollbar를 커스텀 디자인 했습니다

## 📝 상세 내용

- 내부 간격(border과 scrollbar 사이 간격)을 위해 `label`을 외부에 감싸고 `textarea`를 내부에 넣는 식으로 변경했습니다.
- 사용법은 이전과 동일합니다.
- `id`에 대한 리팩토링도 이루어졌습니다.

## 🔗 관련 이슈

Resolves: #134 

## 🖼️ 스크린샷(선택사항)

<img width="661" height="458" alt="image" src="https://github.com/user-attachments/assets/fa918746-d46f-4f38-8499-789b7b356a7b" />

## 💡 참고 사항

- **test code**
```jsx
<Input height='120px' id='textarea' label='label' type='textarea' />
```

- ❓ **왜 `label`로 감싸야 했는가?**
  `textarea`만으로 해결하면 좋겠지만... 그러기엔 어려움이 많습니다. `-webkit-scrollbar`에는 margin, padding 속성이 먹지 않아 여백을 만드려면 border과 transparent 색상을 사용해야 합니다. 다만 현재 디자인에는 한쪽에만 여백이 있어 한쪽에만 border를 주고 `border-radius` 속성을 조정하면 모양이 다소 이상해집니다. 그리고 무엇보다 `-webkit-scrollbar`는 표준이 아니고, firefox 환경에서는 지원이 되지 않는 걸로 알고 있어 `-webkit-scrollbar` 없을 때도 최대한 유사한 디자인을 보여줄 수 있도록 `label`로 감싸 디자인 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Input 컴포넌트의 id prop 전달 방식을 단순화하여 내부적으로 props.id만 사용하도록 개선하였습니다.
  * DropdownInput, PasswordInput, 기본 input 렌더링에서 불필요한 id 전달을 제거하였습니다.
  * TextareaInput 컴포넌트를 새롭게 도입하여 포커스 시 스타일 및 스크롤바 커스터마이징을 적용하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->