### PR TITLE
🐛 fix: Input type='dropdown' 오류 수정 및 스타일/prop 추가

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -59,11 +59,15 @@ type DropdownProps = CommonProps & {
   items: string[];
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'value'>;
 
-const COMMON_STYLE =
-  'txt-16_M h-54 w-full rounded-2xl bg-white border border-gray-100 px-19 py-15 leading-19 outline-none placeholder:text-gray-400';
+const COMMON_STYLE = cn(
+  'h-54 w-full rounded-2xl bg-white border border-gray-100 px-19 py-15 outline-none',
+  'txt-16_M leading-19 placeholder:text-gray-400',
+);
 
-const FOCUS_STYLE =
-  'focus:border-primary-500 focus:border-[1.5px] focus:px-18.5 focus:py-14.5';
+const FOCUS_STYLE = cn(
+  'focus:border-primary-500 focus:border-[1.5px]',
+  'focus:px-18.5 focus:py-14.5',
+);
 
 const SCROLLBAR_STYLE = cn(
   '[&::-webkit-scrollbar]:w-3',
@@ -78,7 +82,12 @@ export default function Input({
   ...props
 }: InputProps | TextareaProps | DropdownProps) {
   const insideInput = () => {
-    const className = `text-gray-950 ${COMMON_STYLE} ${FOCUS_STYLE} ${errorMessage ? 'border-red-500' : ''}`;
+    const className = cn(
+      'text-gray-950',
+      COMMON_STYLE,
+      FOCUS_STYLE,
+      errorMessage ? 'border-red-500' : '',
+    );
 
     switch (props.type) {
       case 'dropdown':

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -125,8 +125,11 @@ function DropdownInput({
   items,
   ...props
 }: DropdownProps) {
-  const [value, setValue] = useState(defaultValue);
+  const [value, setValue] = useState({ item: defaultValue, id: '' });
   const [isOpen, setIsOpen] = useState(false);
+  const elements = useRef(
+    items.map((item) => ({ item, id: crypto.randomUUID() })),
+  );
   const ref = useRef<HTMLInputElement>(null);
 
   const handleClick = (e: MouseEvent<HTMLInputElement>) => {
@@ -140,10 +143,10 @@ function DropdownInput({
     <>
       <input
         ref={ref}
-        className={`${className} ${value ? 'text-gray-950' : 'text-gray-400'} text-start`}
+        className={`${className} ${value.id ? 'text-gray-950' : 'text-gray-400'} text-start`}
         id={id}
         type='button'
-        value={value ?? placeholder ?? ''}
+        value={value.item ?? placeholder ?? ''}
         onClick={handleClick}
         {...props}
       />
@@ -158,20 +161,20 @@ function DropdownInput({
             'shadow-[0_2px_6px_rgba(0,0,0,0.02)]',
           )}
         >
-          {items.map((item) => (
+          {elements.current.map((element) => (
             <button
-              key={item}
+              key={element.id}
               className={cn(
                 'txt-16_M h-48 rounded-xl px-20 text-start text-gray-900',
-                item === value && 'bg-primary-100',
+                element === value && 'bg-primary-100',
               )}
               type='button'
               onClick={() => {
-                setValue(item);
+                setValue(element);
                 setIsOpen(false);
               }}
             >
-              {item}
+              {element.item}
             </button>
           ))}
         </div>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -78,7 +78,11 @@ export default function Input({
     switch (props.type) {
       case 'dropdown':
         return (
-          <DropdownInput className={`${COMMON_STYLE}`} id={id} {...props} />
+          <DropdownInput
+            className={`${COMMON_STYLE} ${FOCUS_STYLE}`}
+            id={id}
+            {...props}
+          />
         );
       case 'textarea':
         return (
@@ -150,7 +154,10 @@ function DropdownInput({
       />
       <div
         className='absolute top-15 right-20'
-        onClick={() => ref.current?.click()}
+        onClick={() => {
+          ref.current?.focus();
+          ref.current?.click();
+        }}
       >
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
       </div>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -194,7 +194,7 @@ function DropdownInput({
                 key={element.key}
                 className={cn(
                   'txt-16_M rounded-xl px-20 py-16 text-start leading-none wrap-break-word text-gray-900',
-                  element === value && 'bg-primary-100',
+                  element.key === value.key && 'bg-primary-100',
                 )}
                 type='button'
                 onClick={() => {

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -177,7 +177,7 @@ function DropdownInput({
             <button
               key={element.key}
               className={cn(
-                'txt-16_M h-48 rounded-xl px-20 text-start text-gray-900',
+                'txt-16_M rounded-xl px-20 py-16 text-start leading-none wrap-break-word text-gray-900',
                 element === value && 'bg-primary-100',
               )}
               type='button'

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -133,7 +133,7 @@ function DropdownInput({
   defaultValue,
   placeholder,
   items,
-  maxHeight,
+  maxHeight = '280px',
   ...props
 }: DropdownProps) {
   const [value, setValue] = useState({ item: defaultValue, key: '' });
@@ -181,7 +181,6 @@ function DropdownInput({
         >
           <div
             className={cn(
-              maxHeight ? '' : 'max-h-256',
               'flex flex-col gap-4 overflow-y-auto pl-3',
               SCROLLBAR_STYLE,
             )}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -148,6 +148,11 @@ function DropdownInput({
     setIsOpen((prev) => !prev);
   };
 
+  const handleIconClick = () => {
+    ref.current?.focus();
+    ref.current?.click();
+  };
+
   useClickOutside(ref, () => setIsOpen(false));
 
   return (
@@ -164,13 +169,7 @@ function DropdownInput({
         onClick={handleClick}
         {...props}
       />
-      <div
-        className='absolute top-15 right-20'
-        onClick={() => {
-          ref.current?.focus();
-          ref.current?.click();
-        }}
-      >
+      <div className='absolute top-15 right-20' onClick={handleIconClick}>
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
       </div>
       {isOpen && (

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -116,7 +116,6 @@ export default function Input({
 }
 
 function DropdownInput({
-  id,
   className,
   type,
   onClick,
@@ -125,10 +124,10 @@ function DropdownInput({
   items,
   ...props
 }: DropdownProps) {
-  const [value, setValue] = useState({ item: defaultValue, id: '' });
+  const [value, setValue] = useState({ item: defaultValue, key: '' });
   const [isOpen, setIsOpen] = useState(false);
   const elements = useRef(
-    items.map((item) => ({ item, id: crypto.randomUUID() })),
+    items.map((item) => ({ item, key: crypto.randomUUID() })),
   );
   const ref = useRef<HTMLInputElement>(null);
 
@@ -143,14 +142,13 @@ function DropdownInput({
     <>
       <input
         ref={ref}
-        className={`${className} ${value.id ? 'text-gray-950' : 'text-gray-400'} text-start`}
-        id={id}
+        className={`${className} ${value.key ? 'text-gray-950' : 'text-gray-400'} text-start`}
         type='button'
         value={value.item ?? placeholder ?? ''}
         onClick={handleClick}
         {...props}
       />
-      <label className='absolute top-15 right-20' htmlFor={id}>
+      <label className='absolute top-15 right-20' htmlFor={props.id}>
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
       </label>
       {isOpen && (
@@ -163,7 +161,7 @@ function DropdownInput({
         >
           {elements.current.map((element) => (
             <button
-              key={element.id}
+              key={element.key}
               className={cn(
                 'txt-16_M h-48 rounded-xl px-20 text-start text-gray-900',
                 element === value && 'bg-primary-100',

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -65,6 +65,12 @@ const COMMON_STYLE =
 const FOCUS_STYLE =
   'focus:border-primary-500 focus:border-[1.5px] focus:px-18.5 focus:py-14.5';
 
+const SCROLLBAR_STYLE = cn(
+  '[&::-webkit-scrollbar]:w-3',
+  '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-200',
+  '[&::-webkit-scrollbar-button]:hidden',
+);
+
 export default function Input({
   className = '',
   label,
@@ -200,12 +206,7 @@ function TextareaInput({ className, height, ...props }: TextareaProps) {
       style={{ height }}
     >
       <textarea
-        className={cn(
-          'block h-full resize-none outline-none',
-          '[&::-webkit-scrollbar]:w-3',
-          '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-200',
-          '[&::-webkit-scrollbar-button]:hidden',
-        )}
+        className={cn('block h-full resize-none outline-none', SCROLLBAR_STYLE)}
         style={{
           scrollbarGutter: 'stable both-edges',
         }}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -223,10 +223,11 @@ function TextareaInput({ className, height, ...props }: TextareaProps) {
       style={{ height }}
     >
       <textarea
-        className={cn('block h-full resize-none outline-none', SCROLLBAR_STYLE)}
-        style={{
-          scrollbarGutter: 'stable both-edges',
-        }}
+        className={cn(
+          'block h-full resize-none pl-3 outline-none',
+          SCROLLBAR_STYLE,
+        )}
+        style={{ scrollbarGutter: 'stable' }}
         onBlur={() => setIsFocused(false)}
         onFocus={() => setIsFocused(true)}
         {...props}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -146,7 +146,11 @@ function DropdownInput({
     <>
       <input
         ref={ref}
-        className={`${className} ${value.item ? 'text-gray-950' : 'text-gray-400'} pr-43 text-start`}
+        className={cn(
+          className,
+          value.item ? 'text-gray-950' : 'text-gray-400',
+          'truncate pr-43 text-start focus:pr-42.5',
+        )}
         type='button'
         value={value.item ?? placeholder ?? ''}
         onClick={handleClick}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -146,7 +146,7 @@ function DropdownInput({
     <>
       <input
         ref={ref}
-        className={`${className} ${value.key ? 'text-gray-950' : 'text-gray-400'} text-start`}
+        className={`${className} ${value.key ? 'text-gray-950' : 'text-gray-400'} pr-43 text-start`}
         type='button'
         value={value.item ?? placeholder ?? ''}
         onClick={handleClick}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -148,12 +148,12 @@ function DropdownInput({
         onClick={handleClick}
         {...props}
       />
-      <label
+      <div
         className='absolute top-15 right-20'
         onClick={() => ref.current?.click()}
       >
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
-      </label>
+      </div>
       {isOpen && (
         <div
           className={cn(

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -174,27 +174,35 @@ function DropdownInput({
       {isOpen && (
         <div
           className={cn(
-            'z-10 flex flex-col gap-4',
-            'absolute top-64 w-full rounded-2xl border border-gray-100 bg-white p-12',
+            'absolute top-64 z-10 w-full rounded-2xl border border-gray-100 bg-white px-8 py-11',
             'shadow-[0_2px_6px_rgba(0,0,0,0.02)]',
           )}
         >
-          {elements.current.map((element) => (
-            <button
-              key={element.key}
-              className={cn(
-                'txt-16_M rounded-xl px-20 py-16 text-start leading-none wrap-break-word text-gray-900',
-                element === value && 'bg-primary-100',
-              )}
-              type='button'
-              onClick={() => {
-                setValue(element);
-                setIsOpen(false);
-              }}
-            >
-              {element.item}
-            </button>
-          ))}
+          <div
+            className={cn(
+              'max-h-256',
+              'flex flex-col gap-4 overflow-y-auto pl-3',
+              SCROLLBAR_STYLE,
+            )}
+            style={{ scrollbarGutter: 'stable' }}
+          >
+            {elements.current.map((element) => (
+              <button
+                key={element.key}
+                className={cn(
+                  'txt-16_M rounded-xl px-20 py-16 text-start leading-none wrap-break-word text-gray-900',
+                  element === value && 'bg-primary-100',
+                )}
+                type='button'
+                onClick={() => {
+                  setValue(element);
+                  setIsOpen(false);
+                }}
+              >
+                {element.item}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -146,7 +146,7 @@ function DropdownInput({
     <>
       <input
         ref={ref}
-        className={`${className} ${value.key ? 'text-gray-950' : 'text-gray-400'} pr-43 text-start`}
+        className={`${className} ${value.item ? 'text-gray-950' : 'text-gray-400'} pr-43 text-start`}
         type='button'
         value={value.item ?? placeholder ?? ''}
         onClick={handleClick}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -148,7 +148,10 @@ function DropdownInput({
         onClick={handleClick}
         {...props}
       />
-      <label className='absolute top-15 right-20' htmlFor={props.id}>
+      <label
+        className='absolute top-15 right-20'
+        onClick={() => ref.current?.click()}
+      >
         <Icon className='size-24 text-gray-950' icon='TriangleDown' />
       </label>
       {isOpen && (

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -57,6 +57,7 @@ type TextareaProps = CommonProps & {
 type DropdownProps = CommonProps & {
   type: 'dropdown';
   items: string[];
+  maxHeight?: string;
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'value'>;
 
 const COMMON_STYLE = cn(
@@ -132,6 +133,7 @@ function DropdownInput({
   defaultValue,
   placeholder,
   items,
+  maxHeight,
   ...props
 }: DropdownProps) {
   const [value, setValue] = useState({ item: defaultValue, key: '' });
@@ -180,11 +182,14 @@ function DropdownInput({
         >
           <div
             className={cn(
-              'max-h-256',
+              maxHeight ? '' : 'max-h-256',
               'flex flex-col gap-4 overflow-y-auto pl-3',
               SCROLLBAR_STYLE,
             )}
-            style={{ scrollbarGutter: 'stable' }}
+            style={{
+              maxHeight: `calc(${maxHeight} - 24px)`,
+              scrollbarGutter: 'stable',
+            }}
           >
             {elements.current.map((element) => (
               <button


### PR DESCRIPTION
## 📌 변경 사항 개요

Input type='dropdown' 에 발생하는 여러 오류와 스타일을 수정했습니다.

## 📝 상세 내용

전체적으로 리팩토링을 진행했습니다.

#### key error
- 들어온 배열 그대로 key를 넣으면 요소가 겹치는 경우에 error가 발생하고, index로 key를 넣는 것은 권장되는 방식이 아닌 것 같았습니다. 그래서 `crypto.randomUUID()`로 랜덤한 UUID를 만들어 key로 설정했습니다.
- items 배열과 각자의 key 값을 객체 형태(`{ item, key }`)로 연동시킨 elements 배열로 map 함수를 돌립니다.

#### icon click error
- 세모 아이콘 클릭 시 펼쳐지기는 잘 펼쳐지지만 닫히는 동작이 먹히지 않아 수정했습니다.

#### Focus 디자인 추가
- 키보드 접근성을 높이기 위해 Focus 디자인을 추가했습니다.

#### Input 내부 padding
- 아이콘 뒤로 텍스트가 보이는 현상을 방지하기 위해 padding 값을 변경해주었습니다.

#### text 넘침 방지
- text가 넘치는 걸 방지하기 위해 input 부분에는 `truncate`, button 부분에는 `wrap-break-word` 스타일을 추가하였습니다.

#### maxHeight
- **`maxHeight` prop이 생겼습니다.** dropdown의 선택지 box 부분의 최대 높이를 설정합니다. `string`으로, 기본값은 `280px`입니다.
- textarea와 동일한 커스텀 스크롤바를 적용했습니다.

## 🔗 관련 이슈

Resolves: #146

## 🖼️ 스크린샷(선택사항)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/a6ed0032-850c-4bb7-bec3-dc0bb621d8a6" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/a0772199-eedc-488f-a052-527b96b50fe5" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/069b6e35-e73a-4f91-97b2-2a12c9ff074c" />


## 💡 참고 사항

테스트 코드
```jsx
<Input
  className='w-320'
  id='id'
  items={[
    'itemitemitemitemitemitemitemitemitemitemitem',
    'item',
    'item',
    'item',
    'item',
    'item',
    'item',
  ]}
  maxHeight='160px'
  placeholder='placeholder'
  type='dropdown'
/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 드롭다운 입력창에 최대 높이(`maxHeight`) 옵션이 추가되어 스크롤 가능한 드롭다운 목록을 지원합니다.

* **스타일**
  * 드롭다운 및 텍스트 영역 입력창의 스크롤바 스타일이 일관성 있게 개선되었습니다.
  * 입력창 및 드롭다운 항목의 스타일링이 개선되었습니다.

* **리팩터링**
  * 드롭다운 항목 관리 및 선택 로직이 개선되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->