### PR TITLE
✨ feat: 인기 체험 섹션 구현

### DIFF
--- a/src/app/_components/CardColumn.tsx
+++ b/src/app/_components/CardColumn.tsx
@@ -22,7 +22,7 @@ export default function CardColumn({
   const formatted = price.toLocaleString();
   return (
     <Link className='flex w-full flex-col' href={`/${id}`}>
-      <div className='relative aspect-[155/177] w-full md:aspect-[332/347] lg:h-290'>
+      <div className='relative aspect-[155/177] w-full md:aspect-[332/347]'>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           alt={`${title} 이미지`}

--- a/src/app/_components/PopularActivities.tsx
+++ b/src/app/_components/PopularActivities.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Image from 'next/image';
+
+import useActivitiesQuery from '@/hooks/activities/useActivitiesQuery';
+
+import PopularActivitiesCarousel from './PopularActivitiesCarousel';
+
+export default function PopularActivities() {
+  const {
+    data: { activities = [], totalCount = 0 } = {},
+    isLoading,
+    isError,
+  } = useActivitiesQuery({
+    method: 'offset',
+    sort: 'most_reviewed',
+    size: 8,
+  });
+
+  return (
+    <div className='flex flex-col gap-14 md:gap-16 lg:gap-20'>
+      <div className='md:txt-32_B txt-18_B leading-26 md:leading-38'>
+        🔥 인기 체험
+      </div>
+      {isLoading && (
+        <div className='flex items-center justify-center'>
+          <div className='border-primary-500 size-50 animate-spin rounded-full border-2 border-t-transparent' />
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <p className='txt-18_M text-center text-red-500'>
+          데이터를 불러오지 못했어요.
+        </p>
+      )}
+
+      {!isLoading && !isError && totalCount === 0 && (
+        <div className='flex flex-col items-center justify-center leading-[normal]'>
+          <Image
+            alt='체험이 없어요'
+            className='p-30'
+            height={182}
+            src='/images/empty-image.png'
+            width={182}
+          />
+          <div className='txt-18_M mb-30 tracking-[-0.45px] text-gray-600'>
+            체험이 존재하지 않아요.
+          </div>
+        </div>
+      )}
+
+      {!isLoading && !isError && totalCount > 0 && (
+        <PopularActivitiesCarousel activities={activities} />
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/PopularActivitiesCarousel.tsx
+++ b/src/app/_components/PopularActivitiesCarousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { TouchEvent, useEffect, useState } from 'react';
 
 import { Activity } from '@/api/types/activities';
 import Icon from '@/components/Icon';
@@ -14,7 +14,7 @@ type ActivityCard = Omit<
 >;
 
 type CarouselProps = {
-  activities: Activity[];
+  activities: ActivityCard[];
 };
 
 export default function PopularActivitiesCarousel({
@@ -25,8 +25,8 @@ export default function PopularActivitiesCarousel({
   const isMobile = useMediaQuery('mobile');
   const isTablet = useMediaQuery('tablet');
 
-  const visibleSlides = isMobile || isTablet ? 2 : 4;
-  const movementCorrection = isTablet ? 10 : 6;
+  const visibleSlides = isMobile || isTablet ? 2 : 4; // 한번에 보여줄 카드 개수
+  const movementCorrection = isTablet ? 10 : 6; // gap으로 인한 보정값
 
   const maxIndex = activities.length - visibleSlides;
 
@@ -34,19 +34,19 @@ export default function PopularActivitiesCarousel({
   const [startX, setStartX] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
 
-  const handleTouchStart = (e) => {
+  const handleTouchStart = (e: TouchEvent<HTMLDivElement>) => {
     if (!isMobile) return;
     setStartX(e.touches[0].clientX);
   };
 
-  const handleTouchMove = (e) => {
+  const handleTouchMove = (e: TouchEvent<HTMLDivElement>) => {
     if (!isMobile) return;
     if (Math.abs(e.touches[0].clientX - startX) > 10) {
       setIsSwiping(true);
     }
   };
 
-  const handleTouchEnd = (e) => {
+  const handleTouchEnd = (e: TouchEvent<HTMLDivElement>) => {
     if (!isMobile || !isSwiping) return;
 
     const endX = e.changedTouches[0].clientX;

--- a/src/app/_components/PopularActivitiesCarousel.tsx
+++ b/src/app/_components/PopularActivitiesCarousel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Activity } from '@/api/types/activities';
+import Icon from '@/components/Icon';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+import CardColumn from './CardColumn';
+
+type ActivityCard = Omit<
+  Activity,
+  'description' | 'address' | 'userId' | 'createdAt' | 'updatedAt'
+>;
+
+type CarouselProps = {
+  activities: Activity[];
+};
+
+export default function PopularActivitiesCarousel({
+  activities,
+}: CarouselProps) {
+  const [index, setIndex] = useState(0);
+
+  const isMobile = useMediaQuery('mobile');
+  const isTablet = useMediaQuery('tablet');
+
+  const visibleSlides = isMobile || isTablet ? 2 : 4;
+  const movementCorrection = isTablet ? 10 : 6;
+
+  const maxIndex = activities.length - visibleSlides;
+
+  // 스와이프 로직 (모바일 전용)
+  const [startX, setStartX] = useState(0);
+  const [isSwiping, setIsSwiping] = useState(false);
+
+  const handleTouchStart = (e) => {
+    if (!isMobile) return;
+    setStartX(e.touches[0].clientX);
+  };
+
+  const handleTouchMove = (e) => {
+    if (!isMobile) return;
+    if (Math.abs(e.touches[0].clientX - startX) > 10) {
+      setIsSwiping(true);
+    }
+  };
+
+  const handleTouchEnd = (e) => {
+    if (!isMobile || !isSwiping) return;
+
+    const endX = e.changedTouches[0].clientX;
+    if (startX > endX) {
+      handleNextClick();
+    } else {
+      handlePrevClick();
+    }
+    setStartX(0);
+    setIsSwiping(false);
+  };
+
+  const handlePrevClick = () => {
+    setIndex((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleNextClick = () => {
+    setIndex((prev) => Math.min(maxIndex, prev + 1));
+  };
+
+  useEffect(() => {
+    setIndex(0);
+  }, [visibleSlides]);
+
+  return (
+    <div className='relative'>
+      <div className='w-full overflow-hidden'>
+        <div
+          className='flex gap-12 transition-transform duration-300 ease-in-out md:gap-20 lg:gap-24'
+          style={{
+            transform: `translateX(calc(-${index} * (100% / ${visibleSlides}) - ${index * movementCorrection}px))`,
+          }}
+          onTouchEnd={handleTouchEnd}
+          onTouchMove={handleTouchMove}
+          onTouchStart={handleTouchStart}
+        >
+          {activities.map((activity) => (
+            <div
+              key={activity.id}
+              className='w-[calc((100%-12px)/2)] flex-none md:w-[calc((100%-20px)/2)] lg:w-[calc((100%-72px)/4)]'
+            >
+              <CardColumn {...activity} />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {!isMobile && (
+        <>
+          {index > 0 && (
+            <button
+              className='card-shadow absolute top-1/2 -left-27 z-10 flex size-54 -translate-y-1/2 items-center justify-center rounded-full border border-[rgba(0,0,0,0.3)] bg-white hover:bg-gray-100'
+              onClick={handlePrevClick}
+            >
+              <Icon className='size-24' icon='ArrowLeft' />
+            </button>
+          )}
+          {index < maxIndex && (
+            <button
+              className='card-shadow absolute top-1/2 -right-27 z-10 flex size-54 -translate-y-1/2 items-center justify-center rounded-full border border-[rgba(0,0,0,0.3)] bg-white hover:bg-gray-100'
+              onClick={handleNextClick}
+            >
+              <Icon className='size-24' icon='ArrowRight' />
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import AllActivities from './_components/AllActivities';
+import PopularActivities from './_components/PopularActivities';
 
 export default function Home() {
   return (
     <div className='mx-auto max-w-1200'>
-      <div className='mx-24 min-h-800 md:mx-30 lg:mx-40'>
+      <div className='mx-24 flex min-h-800 flex-col gap-40 pb-136 md:mx-30 md:gap-80 md:pb-204 lg:mx-40 lg:pb-218'>
+        <PopularActivities />
         <AllActivities />
       </div>
     </div>


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
메인 페이지에 추가될 인기 체험 활동 캐러셀 컴포넌트를 구현했습니다. 이 컴포넌트는 반응형으로 동작하여, **모바일 환경에서는 터치 스와이프로, 태블릿 및 데스크톱 환경에서는 버튼**으로 콘텐츠를 탐색할 수 있습니다.
리뷰 많은 순으로 8개를 불러와서 보여줍니다.
## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
## Components
### `PopularActivitiesCarousel.tsx`
- useMediaQuery 훅을 사용하여 현재 뷰포트에 따라 보여주는 카드 개수를 동적으로 조절합니다.
  - 모바일/태블릿: 2개
  - 데스크톱: 4개
- 태블릿/데스크톱: 좌/우 화살표 버튼을 통해 캐러셀을 이동시킬 수 있도록 했습니다. 버튼은 캐러셀의 처음과 끝에서는 비활성화됩니다.
- 모바일: onTouchStart, onTouchMove, onTouchEnd 이벤트를 조합하여 사용자가 직접 화면을 쓸어넘기는 스와이프 제스처로 캐러셀을 조작할 수 있도록 구현했습니다.
- CSS transform: translateX 속성을 이용해 부드러운 슬라이드 애니메이션을 적용했습니다.
- 카드 사이의 gap으로 인해 발생하는 위치 오차를 movementCorrection 값을 통해 보정하여, index가 변경될 때마다 정확한 위치에 카드가 표시되도록 했습니다.
- 상태 초기화: 화면 크기가 변경되어 보이는 카드 개수가 바뀔 때(visibleSlides 변경), useEffect를 사용해 캐러셀 인덱스를 0으로 초기화하여 UI가 깨지지 않도록 처리했습니다.

### `PopularActivities.tsx`
- useActivitiesQuery를 활용해 리뷰가 많은 순으로 상위 8개의 체험을 불러옵니다.
- 해당 체험들을 PopularActivitiesCarousel에 전달하여 캐러셀로 보여줍니다.
- 로딩 시 스피너를 보여주며, 에러 발생 시 에러발생 텍스트를 보여줍니다.
- 체험이 없을 시 체험이 존재하지 않는다는 문구를 보여주며, 그 외의 경우 캐러셀 형태로 체험들을 보여줍니다.
## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #126 

## 🖼️ 스크린샷(선택사항)

PC, Tablet
![제목 없는 동영상 - Clipchamp로 제작 (6)](https://github.com/user-attachments/assets/d63418e0-67d8-457f-b886-14bbea2d3eb6)

Mobile
![제목 없는 동영상 - Clipchamp로 제작 (5)](https://github.com/user-attachments/assets/1cd15717-d741-4d8d-83ab-c009d953e814)


## 💡 참고 사항
이상한점 있으면 말씀 부탁드립니다 _ _

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 인기 액티비티 목록을 보여주는 섹션이 추가되었습니다. 리뷰가 많은 순으로 최대 8개의 인기 액티비티를 확인할 수 있습니다.
  * 인기 액티비티는 가로 스크롤 가능한 캐러셀 형태로 제공되며, 모바일에서는 터치 스와이프, 데스크톱에서는 화살표 버튼으로 이동할 수 있습니다.

* **Style**
  * 카드 이미지 영역의 높이 스타일이 일부 화면 크기에서 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->