### PR TITLE
✨ feat : 예약 현황 페이지 로딩 및 빈페이지 구현

### DIFF
--- a/src/app/mypage/reserve-status/page.tsx
+++ b/src/app/mypage/reserve-status/page.tsx
@@ -8,15 +8,17 @@ import {
 } from '@/hooks/myActivities/useMyActivitiesQuery';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { formatDateForAPI } from '@/utils/dateUtils';
+import getErrorMessage from '@/utils/getErrorMessage';
 
 import { Calendar } from './_components/calendar/Calendar';
 import { MyActListDropDown } from './_components/MyActListDropDown';
 import { ReservationModal } from './_components/ReservationModal';
 
 export default function Page() {
-  const { data } = useMyActQuery();
+  const { data, isLoading, isError, error } = useMyActQuery();
   const { selectedActivityId, currentDate, setReservations } =
     useCalendarStore();
+  const errorMessage = getErrorMessage(error, '예약 내역 조회에 실패했습니다');
 
   // 항상 훅을 호출하되, selectedActivityId가 없으면 0을 전달
 
@@ -47,19 +49,41 @@ export default function Page() {
     }
   }, [reservationDashboard, selectedActivityId, setReservations]);
 
-  if (!data) return null;
+  if (!data || !data.activities || data.activities.length === 0) {
+    return (
+      <div className='flex w-full flex-col gap-13 md:gap-30'>
+        <ReservationStatusHeader />
+        <div className='flex flex-col items-center justify-center leading-[normal]'>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt='체험이 없어요'
+            className='size-182 p-30'
+            src='/images/empty-image.png'
+          />
+          <div className='txt-18_M mb-30 tracking-[-0.45px] text-gray-600'>
+            아직 등록한 체험이 없어요
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className='flex w-full items-center justify-center py-100'>
+        <div className='border-primary-500 size-50 animate-spin rounded-full border-2 border-t-transparent' />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div>에러:{errorMessage}</div>;
+  }
 
   if (!selectedActivityId) {
     return (
       <div className='flex w-full flex-col gap-30 max-md:gap-18 md:max-lg:gap-24'>
-        <div className='flex flex-col items-start justify-center gap-10 py-10 leading-[normal]'>
-          <span className='txt-18_B tracking-[-0.45px] text-gray-950'>
-            예약 현황
-          </span>
-          <span className='txt-14_M tracking-[-0.35px] text-gray-500'>
-            내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
-          </span>
-        </div>
+        <ReservationStatusHeader />
         <MyActListDropDown activities={data.activities} />
       </div>
     );
@@ -67,17 +91,23 @@ export default function Page() {
 
   return (
     <div className='relative mb-30 flex w-full flex-col gap-30 max-md:gap-18 md:max-lg:gap-24'>
-      <div className='flex flex-col items-start justify-center gap-10 py-10 leading-[normal]'>
-        <span className='txt-18_B tracking-[-0.45px] text-gray-950'>
-          예약 현황
-        </span>
-        <span className='txt-14_M tracking-[-0.35px] text-gray-500'>
-          내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
-        </span>
-      </div>
+      <ReservationStatusHeader />
       <MyActListDropDown activities={data.activities} />
       <Calendar />
       <ReservationModal />
+    </div>
+  );
+}
+
+function ReservationStatusHeader() {
+  return (
+    <div className='flex flex-col items-start justify-center gap-10 py-10 leading-[normal]'>
+      <span className='txt-18_B tracking-[-0.45px] text-gray-950'>
+        예약 현황
+      </span>
+      <span className='txt-14_M tracking-[-0.35px] text-gray-500'>
+        내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
+      </span>
     </div>
   );
 }

--- a/src/app/mypage/reserves/_components/ReservesFilter.tsx
+++ b/src/app/mypage/reserves/_components/ReservesFilter.tsx
@@ -31,7 +31,7 @@ export default function ReservesFilter({
     >
       <FilterHeader />
       {isEmpty ? (
-        <div className='] flex flex-col items-center justify-center leading-[normal]'>
+        <div className='flex flex-col items-center justify-center leading-[normal]'>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             alt='예약이 없어요'


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
예약 현황 페이지 로딩 및 빈페이지 경우 구현

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
예약 현황 페이지에 로딩일때 화면에 스피너가 돌아가게했습니다(진우님의 스피너 사용)
체험이 하나도 없는 경우에 대한 빈페이지를 구현했습니다

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

Resolves: #177 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
<img width="949" height="403" alt="image" src="https://github.com/user-attachments/assets/17b216c9-db94-4606-b3d3-6cfb7385cd13" />
<img width="1210" height="679" alt="image" src="https://github.com/user-attachments/assets/6ab2bccc-4b8f-4829-8808-b329b1579927" />


## 💡 참고 사항
