### PR TITLE
🐛 fix: 이미지가 세로로 길 경우 카드가 이상하게 보이는 현상 수정

### DIFF
--- a/src/app/_components/CardColumn.tsx
+++ b/src/app/_components/CardColumn.tsx
@@ -22,11 +22,11 @@ export default function CardColumn({
   const formatted = price.toLocaleString();
   return (
     <Link className='flex w-full flex-col' href={`/${id}`}>
-      <div className='relative aspect-[155/177] w-full md:aspect-[332/347]'>
+      <div className='relative'>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           alt={`${title} 이미지`}
-          className='h-full w-full rounded-[18px] object-cover md:rounded-[32px]'
+          className='aspect-[155/177] h-full w-full rounded-[18px] object-cover md:aspect-[332/347] md:rounded-[32px]'
           src={bannerImageUrl || '/images/logo-lg.png'}
           onError={(e) => {
             e.currentTarget.src = '/images/logo-lg.png';


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
세로로 긴 이미지의 경우 카드의 높이도 길어지는 현상을 수정했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
상위 div에 있던 클래스를 하위 img로 내렸습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- Resolves: #37 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
기존 
<img width="1397" height="555" alt="image" src="https://github.com/user-attachments/assets/80d9f5bd-fc7f-4244-ac02-009e0bb15e8a" />

현재
<img width="1160" height="367" alt="image" src="https://github.com/user-attachments/assets/6d3b2712-f51d-4616-b89f-15c456eca1e6" />


## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 이미지의 비율 및 스타일이 개선되어 다양한 화면 크기에서 더 일관된 이미지 표시가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->