### PR TITLE
✨ feat: 리다이렉트URL수정

### DIFF
--- a/src/utils/oauth/getRedirectUrl.ts
+++ b/src/utils/oauth/getRedirectUrl.ts
@@ -1,19 +1,24 @@
-//카카오로 로그인 버튼을 눌렀을 때 리다이렉트 될 URL
 export function getRedirectUrl(flow: 'login' | 'signUp'): string {
   const REST_API_KEY = process.env.NEXT_PUBLIC_OAUTH_APP_KEY;
   const APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+  const VERCEL_HOST = process.env.NEXT_PUBLIC_VERCEL_URL;
 
   if (!REST_API_KEY) {
     throw new Error(
       'NEXT_PUBLIC_OAUTH_APP_KEY 환경변수가 설정되지 않았습니다.',
     );
   }
-
   if (!APP_URL) {
     throw new Error('NEXT_PUBLIC_APP_URL 환경변수가 설정되지 않았습니다.');
   }
 
-  const REDIRECT_URI = `${APP_URL}/login/callback`;
+  const isProduction = process.env.NODE_ENV === 'production';
+  const baseUrl =
+    isProduction && VERCEL_HOST
+      ? VERCEL_HOST.replace(/\/$/, '')
+      : APP_URL.replace(/\/$/, '');
+
+  const REDIRECT_URI = `${baseUrl}/login/callback`;
 
   const params = new URLSearchParams({
     client_id: REST_API_KEY,


### PR DESCRIPTION
## 📌 변경 사항 개요

리다이렉트URL수정

## 📝 상세 내용

개발자 로컬에서 테스트할 때는 localhost로, 배포된 서비스에서는 Vercel 도메인으로 콜백 요청을 보낼 수 있도록 작업했습니다


## 🔗 관련 이슈

 Resolves: #194

## 🖼️ 스크린샷(선택사항)


## 💡 참고 사항

env.local 파일 내용은 zep을 확인해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카카오 OAuth 로그인 및 회원가입 시 환경 변수에 따라 리다이렉트 URI가 동적으로 처리되어, 환경에 맞는 인증 흐름이 안정적으로 동작합니다.

* **리팩터링**
  * 로그인과 회원가입 처리 로직이 통합되어 인증 과정이 더 명확하고 일관되게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->