### PR TITLE
🐛 fix: 이미지 업로드 API 함수 content-type header 지정

### DIFF
--- a/src/api/activitiesApi.ts
+++ b/src/api/activitiesApi.ts
@@ -76,6 +76,11 @@ const activitiesDetailApi = {
     return apiClient.post<FormData, ActivityImageUploadResponse>(
       `/activities/image`,
       formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
     );
   },
 };

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -36,6 +36,11 @@ const userApi = {
     return apiClient.post<FormData, UploadProfileImageResponse>(
       '/users/me/image',
       formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
     );
   },
 };


### PR DESCRIPTION
## 📌 변경 사항 개요

uploadImage와 uploadProfileImage API 함수에 content-type header를 추가했습니다

## 📝 상세 내용

`application/json` content-type으로 헤더가 지정되어 400 Bad Request 오류가 발생하는 부분을 수정하였습니다.

## 🔗 관련 이슈

Resolves: #196
Related to: #81 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 이미지 업로드 시 올바른 HTTP 헤더(`Content-Type: multipart/form-data`)가 적용되어 파일 업로드 호환성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->