### PR TITLE
🐛 fix: mypage state 초기화 문제 수정

### DIFF
--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -4,32 +4,47 @@ import { usePathname } from 'next/navigation';
 
 import SideMenu from '@/components/side-menu/SideMenu';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { cn } from '@/utils/cn';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const isMobile = useMediaQuery('mobile');
   const pathname = usePathname();
+  const isMyPageRoot = pathname === '/mypage';
 
-  // 모바일 + /mypage 루트일 때만 SideMenu만 보여줌
-  if (isMobile && pathname === '/mypage') {
-    return (
-      <div className='mt-35 flex items-center justify-center'>
-        <SideMenu />
-      </div>
-    );
-  } else if (isMobile) {
-    return (
-      <div className='mx-24 mt-30 flex items-center justify-center'>
-        {children}
-      </div>
-    );
-  }
-
-  // 그 외에는 children도 같이 보여줌
   return (
-    <div className='flex items-center justify-center'>
-      <div className='mt-40 flex w-full max-w-980 items-start justify-between min-md:mx-30 min-md:gap-30'>
-        <SideMenu />
-        <main className='flex w-640 flex-col items-start justify-center'>
+    <div
+      className={cn(
+        'flex justify-center',
+        // 모바일/데스크탑에 따라 다른 외부 여백과 정렬 적용
+        {
+          'mt-35 items-center': isMobile && isMyPageRoot,
+          'mx-24 mt-30': isMobile && !isMyPageRoot,
+          'mt-40': !isMobile,
+        },
+      )}
+    >
+      <div
+        className={cn(
+          'flex w-full items-start',
+          // 데스크탑에서는 최대 너비와 좌우 간격 적용
+          !isMobile && 'max-w-980 justify-between min-md:mx-30 min-md:gap-30',
+          // 모바일에서는 중앙 정렬
+          isMobile && 'justify-center',
+        )}
+      >
+        {/* SideMenu: 데스크탑에서는 항상, 모바일에서는 /mypage 에서만 보임 */}
+        <div className={cn({ hidden: isMobile && !isMyPageRoot })}>
+          <SideMenu />
+        </div>
+
+        {/* children: 데스크탑에서는 항상, 모바일에서는 /mypage가 아닐 때만 보임 */}
+        <main
+          className={cn('flex flex-col items-start justify-center', {
+            'w-640': !isMobile, // 데스크탑 너비
+            'w-full': isMobile && !isMyPageRoot, // 모바일 너비
+            hidden: isMobile && isMyPageRoot, // /mypage 에서는 숨김
+          })}
+        >
           {children}
         </main>
       </div>


### PR DESCRIPTION
## 📌 변경 사항 개요

마이페이지(`src/app/mypage/**`) 관련 레이아웃에서 화면 크기(모바일/데스크톱)가 변경되거나 페이지가 전환될 때, 하위 페이지 컴포넌트의 내부 상태(`state`)가 초기화되는 버그를 수정했습니다. 조건부 렌더링으로 JSX 구조를 변경하는 대신, 일관된 컴포넌트 구조를 유지하고 CSS 클래스를 통해 가시성을 제어하는 방식으로 리팩토링하여 상태 유실을 방지했습니다.

## 📝 상세 내용

### AS-IS (기존 문제)

-   `src/app/mypage/layout.tsx` 파일에서 `useMediaQuery` 훅으로 감지한 `isMobile` 값과 `usePathname`의 경로에 따라 `if/else` 분기를 통해 완전히 다른 JSX 구조를 반환했습니다.
-   이러한 방식은 화면 크기나 경로가 변경될 때마다 React가 컴포넌트 트리가 달라졌다고 판단하여, 기존 컴포넌트를 언마운트(Unmount)하고 새로운 컴포넌트를 마운트(Mount)하는 현상을 유발했습니다.
-   결과적으로 `children`으로 렌더링 되던 페이지 컴포넌트의 `useState`, `useReducer` 등으로 관리되던 내부 상태가 모두 초기화되었습니다. (예: 입력 폼에 내용을 작성하다가 화면 크기를 바꾸면 내용이 사라짐)

### TO-BE (개선 사항)

-   `if/else` 조건 분기를 제거하고, 모든 경우에 동일한 단일 JSX 구조를 반환하도록 로직을 변경했습니다.
-   `cn` 유틸리티 함수를 사용하여 조건에 따라 동적으로 CSS 클래스(`hidden` 등)를 적용하는 방식으로 UI의 가시성을 제어합니다.
    -   **SideMenu**: 데스크톱에서는 항상 보이고, 모바일에서는 `/mypage` 경로에서만 보입니다.
    -   **main (children)**: 데스크톱에서는 항상 보이고, 모바일에서는 `/mypage` 경로가 아닐 때만 보입니다.
-   이를 통해 컴포넌트 트리의 구조적 일관성이 유지되어 React가 컴포넌트를 불필요하게 언마운트하지 않으므로, `children` 페이지의 내부 상태가 화면 전환에도 안정적으로 유지됩니다.

## 🔗 관련 이슈

-   Resolves: #198 

## 🖼️ 스크린샷(선택사항)
-  개선전
![recording-_3_](https://github.com/user-attachments/assets/455bb970-1e98-4bbe-bbb3-9e6092112c9e)
- 개선 후
![recording-_4_](https://github.com/user-attachments/assets/389f0979-8c89-4304-8dd3-741c4cf9dc21)


## 💡 참고 사항

이번 리팩토링의 핵심은 **DOM 구조의 일관성**을 유지하여 React의 예측 가능한 렌더링을 유도하고, 불필요한 상태 초기화를 방지하는 것입니다. `cn` 유틸리티를 활용하여 조건부 스타일링을 깔끔하게 처리함으로써 코드의 가독성과 유지보수성을 높였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 마이페이지 레이아웃이 모바일과 데스크톱 환경에서 더욱 일관성 있게 표시되도록 구조가 개선되었습니다.  
  * 모바일에서 `/mypage` 루트 경로일 때와 그 외 경로, 데스크톱 환경에서 각각의 레이아웃이 명확하게 구분되어 보여집니다.  
  * 시각적 구성이 더욱 직관적으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->