### PR TITLE
✨ feat: 404 페이지 구현 

### DIFF
--- a/src/app/[activityId]/page.tsx
+++ b/src/app/[activityId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import activitiesDetailApi from '@/api/activitiesApi';
@@ -21,8 +22,7 @@ export default function ActivityDetail() {
 
     const id = Number(activityId);
     if (isNaN(id)) {
-      setError('잘못된 체험 ID입니다.');
-      return;
+      notFound();
     }
 
     const fetchData = async () => {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className='flex h-screen flex-col items-center justify-center gap-50 text-center'>
+      {/* '404' 시각적 표현 */}
+      <div className='flex items-center justify-center'>
+        <span className='text-8xl font-bold text-gray-400 md:text-9xl'>4</span>
+        <Image
+          alt='페이지 없음'
+          className='mx-4 md:size-130'
+          height={100}
+          src='/images/empty-image.png'
+          width={100}
+        />
+        <span className='text-8xl font-bold text-gray-400 md:text-9xl'>4</span>
+      </div>
+
+      <div className='flex flex-col items-center justify-center gap-10'>
+        <h2 className='text-xl font-semibold lg:text-2xl'>
+          죄송합니다. 페이지를 찾을 수 없습니다.
+        </h2>
+        <p className='text-base text-gray-600'>
+          요청하신 페이지가 존재하지 않거나,
+          <br className='md:hidden' />
+          다른 위치로 이동했을 수 있습니다.
+        </p>
+        <Link
+          className='txt-16_B bg-primary-500 flex w-200 items-center justify-center rounded-2xl px-40 py-13 tracking-[-0.4px] text-white'
+          href='/'
+        >
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

사용자가 존재하지 않는 페이지에 접근했을 때 일관된 경험을 제공하기 위해 **전역 404 에러 페이지**를 새로 제작하고 적용했습니다. 또한, 잘못된 체험 ID로 상세 페이지 접근 시에도 이 새로운 404 페이지가 표시되도록 에러 처리 로직을 개선했습니다

## 📝 상세 내용

### 1. 전역 404 페이지 추가 및 디자인

-   **파일 생성**: `app/not-found.tsx` 파일을 생성하여 앱 라우터의 규칙에 따라 사이트 전체에 적용될 공통 404 페이지를 구현했습니다.
-   **디자인**:
    -   숫자 '4' 사이에 이미지를 배치하여 404를 귀엽게 디자인해봤습니다
    -   모바일과 데스크톱 환경에 모두 대응할 수 있도록 텍스트, 이미지, 레이아웃 등을 **반응형으로 디자인**했습니다.
    -   사용자가 쉽게 사이트로 복귀할 수 있도록 '홈으로 돌아가기' 버튼을 명확하게 제공합니다.

### 2. 체험 상세 페이지 에러 처리 개선

-   **AS-IS**: 이전에는 `app/[activityId]/page.tsx`에서 유효하지 않은 체험 ID로 접근할 경우, 페이지 내부에 간단한 텍스트로 에러를 표시했습니다.
-   **TO-BE**: 페이지 내부에서 자체적으로 에러를 처리하던 로직을 Next.js의 `notFound()` 함수를 호출하는 방식으로 변경했습니다. 이제 잘못된 체험 ID로 접근하면, 새로 만든 **전역 404 페이지로 일관되게 안내**합니다.


## 🔗 관련 이슈

<!-- Resolves: #이슈번호 -->
Resolves: #200 

## 🖼️ 스크린샷(선택사항)
<img width="827" height="1033" alt="image" src="https://github.com/user-attachments/assets/41a624c2-a4ff-4489-98ba-e2c708ee1f3f" />
<img width="851" height="984" alt="image" src="https://github.com/user-attachments/assets/bb363392-22f6-433b-9926-7ee50d944ccb" />
<img width="1583" height="966" alt="image" src="https://github.com/user-attachments/assets/c50708f3-c063-4a62-a460-822350112754" />



## 💡 참고 사항
<img width="1606" height="603" alt="image" src="https://github.com/user-attachments/assets/acf037fb-25f6-434b-b62c-b05cfbcc12ce" />
이부분은 안건들이고 이상하게  ex)http://localhost:3000/dsfsf 이런식으로 쳤을때만 에러페이지 뜨게 설정했습니다~