### PR TITLE
✨ feat: 내 정보 수정 페이지 구현 및 프로필 이미지 업로드 관련 수정

### DIFF
--- a/src/app/mypage/info/page.tsx
+++ b/src/app/mypage/info/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { FormEvent, useEffect, useState } from 'react';
 
 import userApi from '@/api/userApi';
@@ -10,6 +11,8 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useUserStore } from '@/stores/userStore';
 
 export default function Page() {
+  const router = useRouter();
+
   const user = useUserStore((s) => s.user);
   const setUser = useUserStore((s) => s.setUser);
 
@@ -132,6 +135,7 @@ export default function Page() {
             size='md'
             type='button'
             variant='secondary'
+            onClick={() => router.push('/mypage')}
           >
             취소하기
           </Button>

--- a/src/app/mypage/info/page.tsx
+++ b/src/app/mypage/info/page.tsx
@@ -87,7 +87,7 @@ export default function Page() {
   return (
     <>
       <form
-        className='flex w-full flex-col gap-20 pb-55 md:gap-24 md:pb-275'
+        className='flex w-full flex-col gap-20 md:gap-24'
         onSubmit={handleSubmit}
       >
         <div className='flex flex-col gap-10 py-10'>

--- a/src/app/mypage/info/page.tsx
+++ b/src/app/mypage/info/page.tsx
@@ -1,3 +1,158 @@
-export default function page() {
-  return <div>마이 페이지 상세 정보페이지입니다</div>;
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+
+import userApi from '@/api/userApi';
+import Button from '@/components/Button';
+import Input from '@/components/Input';
+import Modal from '@/components/Modal/Modal';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { useUserStore } from '@/stores/userStore';
+
+export default function Page() {
+  const user = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+
+  const [nickname, setNickname] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordCheck, setPasswordCheck] = useState('');
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  const [nicknameError, setNicknameError] = useState(false);
+  const [passwordError, setPasswordError] = useState(false);
+  const [passwordCheckError, setPasswordCheckError] = useState(false);
+
+  const isMobile = useMediaQuery('mobile');
+  useEffect(() => {
+    if (user) {
+      setNickname(user.nickname);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    setPasswordError(password.length > 0 && password.length < 8);
+    setPasswordCheckError(
+      passwordCheck.length > 0 && password !== passwordCheck,
+    );
+  }, [password, passwordCheck]);
+
+  useEffect(() => {
+    setNicknameError(!nickname.trim());
+  }, [nickname]);
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!nickname.trim()) {
+      setModalMessage('닉네임을 입력해주세요.');
+      setIsModalOpen(true);
+      return;
+    }
+
+    if (password && password.length < 8) {
+      setModalMessage('비밀번호는 8자 이상이어야 합니다.');
+      setIsModalOpen(true);
+      return;
+    }
+
+    if (password && password !== passwordCheck) {
+      setModalMessage('비밀번호가 일치하지 않습니다.');
+      setIsModalOpen(true);
+      return;
+    }
+
+    try {
+      const updated = await userApi.updateMyInfo({
+        nickname,
+        newPassword: password || undefined,
+      });
+
+      setUser(updated);
+      setModalMessage('정보가 수정되었습니다!');
+      setIsModalOpen(true);
+    } catch (e) {
+      setModalMessage(e.response?.data?.message || '정보 수정에 실패했습니다.');
+      setIsModalOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <form
+        className='flex w-full flex-col gap-20 pb-55 md:gap-24 md:pb-275'
+        onSubmit={handleSubmit}
+      >
+        <div className='flex flex-col gap-10 py-10'>
+          <h1 className='txt-18_B leading-21 text-gray-950'>내 정보</h1>
+          <p className='txt-14_M leading-17 text-gray-500'>
+            닉네임과 비밀번호를 수정하실 수 있습니다.
+          </p>
+        </div>
+
+        <div className='flex flex-col gap-18 md:gap-24'>
+          <Input
+            errorMessage={nicknameError ? '닉네임을 입력해주세요.' : ''}
+            id='nickname'
+            label='닉네임'
+            type='text'
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+          />
+          <Input
+            readOnly
+            id='email'
+            label='이메일'
+            type='email'
+            value={user?.email || ''}
+          />
+          <Input
+            errorMessage={passwordError ? '8자 이상 작성해주세요.' : ''}
+            id='password'
+            label='비밀번호'
+            type='password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Input
+            errorMessage={
+              passwordCheckError ? '비밀번호가 일치하지 않습니다.' : ''
+            }
+            id='passwordcheck'
+            label='비밀번호 확인'
+            type='password'
+            value={passwordCheck}
+            onChange={(e) => setPasswordCheck(e.target.value)}
+          />
+        </div>
+        <div className='flex justify-center gap-12 pt-12 md:pt-0'>
+          <Button
+            className='max-w-none md:hidden'
+            rounded='14'
+            size='md'
+            type='button'
+            variant='secondary'
+          >
+            취소하기
+          </Button>
+          <Button
+            className='max-w-none md:w-120'
+            rounded={isMobile ? '14' : '12'}
+            size={isMobile ? 'md' : 'sm'}
+            type='submit'
+          >
+            저장하기
+          </Button>
+        </div>
+      </form>
+
+      {isModalOpen && (
+        <Modal
+          message={modalMessage}
+          variant='onlyText'
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
+    </>
+  );
 }

--- a/src/app/mypage/info/page.tsx
+++ b/src/app/mypage/info/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useEffect, useState } from 'react';
 
@@ -75,7 +76,10 @@ export default function Page() {
       setModalMessage('정보가 수정되었습니다!');
       setIsModalOpen(true);
     } catch (e) {
-      setModalMessage(e.response?.data?.message || '정보 수정에 실패했습니다.');
+      const error = e as AxiosError<{ message?: string }>;
+      setModalMessage(
+        error.response?.data?.message || '정보 수정에 실패했습니다.',
+      );
       setIsModalOpen(true);
     }
   };

--- a/src/app/mypage/info/page.tsx
+++ b/src/app/mypage/info/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { AxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useEffect, useState } from 'react';
 
@@ -10,6 +9,7 @@ import Input from '@/components/Input';
 import Modal from '@/components/Modal/Modal';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useUserStore } from '@/stores/userStore';
+import getErrorMessage from '@/utils/getErrorMessage';
 
 export default function Page() {
   const router = useRouter();
@@ -76,10 +76,7 @@ export default function Page() {
       setModalMessage('정보가 수정되었습니다!');
       setIsModalOpen(true);
     } catch (e) {
-      const error = e as AxiosError<{ message?: string }>;
-      setModalMessage(
-        error.response?.data?.message || '정보 수정에 실패했습니다.',
-      );
+      setModalMessage(getErrorMessage(e, '정보 수정에 실패했습니다.'));
       setIsModalOpen(true);
     }
   };

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -19,7 +19,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         {
           'mt-35 items-center': isMobile && isMyPageRoot,
           'mx-24 mt-30': isMobile && !isMyPageRoot,
-          'mt-40': !isMobile,
+          'mx-30 mt-40': !isMobile,
         },
       )}
     >

--- a/src/components/side-menu/Profile.tsx
+++ b/src/components/side-menu/Profile.tsx
@@ -37,7 +37,7 @@ export default function Profile() {
 
   if (!user) {
     return (
-      <div className='flex h-120 items-center justify-center min-md:max-[1023px]:h-70'>
+      <div className='flex h-120 items-center justify-center md:max-lg:h-70'>
         <div className='border-primary-500 size-20 animate-spin rounded-full border-2 border-t-transparent' />
       </div>
     );

--- a/src/components/side-menu/Profile.tsx
+++ b/src/components/side-menu/Profile.tsx
@@ -3,6 +3,7 @@
 import userApi from '@/api/userApi';
 import { useImageUpload } from '@/hooks/useImageUpload';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { useUserStore } from '@/stores/userStore';
 import { cn } from '@/utils/cn';
 
 import Icon from '../Icon';
@@ -10,14 +11,21 @@ import ImageUploader from '../ImageUploader';
 
 export default function Profile() {
   const isTablet = useMediaQuery('tablet');
+  const user = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+
   const { previewUrl, isUploading, handleChange } = useImageUpload({
-    defaultImage: '/images/profile-default.svg',
+    defaultImage: user?.profileImageUrl || '/images/profile-default.svg',
     uploadFn: async (file: File) => {
       try {
         const result = await userApi.uploadProfileImage(file);
         if (!result?.profileImageUrl) {
           throw new Error('업로드된 이미지 URL을 받을 수 없습니다');
         }
+        const updated = await userApi.updateMyInfo({
+          profileImageUrl: result.profileImageUrl,
+        });
+        setUser(updated);
         return result.profileImageUrl;
       } catch (error) {
         console.error('프로필 이미지 업로드 실패:', error);
@@ -27,13 +35,26 @@ export default function Profile() {
   });
   const size = isTablet ? 70 : 120;
 
+  if (!user) {
+    return (
+      <div className='flex h-120 items-center justify-center min-md:max-[1023px]:h-70'>
+        <div className='border-primary-500 size-20 animate-spin rounded-full border-2 border-t-transparent' />
+      </div>
+    );
+  }
+
+  const displayUrl =
+    previewUrl && previewUrl.startsWith('blob:')
+      ? previewUrl
+      : user?.profileImageUrl || '/images/profile-default.svg';
+
   return (
     <div className='relative h-120 w-120 min-md:max-[1023px]:h-70 min-md:max-[1023px]:w-70'>
       <img
         alt='프로필 이미지'
         className='aspect-square rounded-full object-cover'
         height={size}
-        src={previewUrl}
+        src={displayUrl}
         width={size}
       />
 

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import type { UserProfile } from '@/api/types/auth';
 
@@ -8,8 +9,15 @@ export interface UserState {
   clearUser: () => void;
 }
 
-export const useUserStore = create<UserState>((set) => ({
-  user: null,
-  setUser: (u) => set({ user: u }),
-  clearUser: () => set({ user: null }),
-}));
+export const useUserStore = create<UserState>(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (u) => set({ user: u }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'user-storage',
+    },
+  ),
+);

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -9,7 +9,7 @@ export interface UserState {
   clearUser: () => void;
 }
 
-export const useUserStore = create<UserState>(
+export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       user: null,


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 내 정보 수정 페이지 (`mypage/info`) 구현
- 이미지 업로드가 잘 안되는 문제 해결

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- 내 정보 페이지에서 닉네임과 비밀번호를 변경할 수 있습니다.
- 이메일은 변경이 불가하므로, readonly 로 넣어뒀습니다.
- 닉네임은 1 ~ 10자 제한이 걸려있습니다.
- 비밀번호는 8자 이상 제한이 걸려있으며, 비밀번호 확인과 일치해야 합니다.
- 원하는 정보를 수정한 후 버튼을 클릭 시 정보가 업데이트됩니다.
- 모바일에서 취소버튼을 클릭 시 /mypage로 이동합니다.
- userStore에 persist 미들웨어를 추가했습니다. (새로고침 시 데이터 삭제되는 문제 해결)

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
 Resolves: #191 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
- PC
<img width="1679" height="1395" alt="image" src="https://github.com/user-attachments/assets/e81c0478-f8a1-49c1-9318-cb600d0fe7f8" />

- Tablet
<img width="860" height="1147" alt="image" src="https://github.com/user-attachments/assets/74e42f15-ff31-4281-8362-a69405c9143b" />

- Mobile
<img width="588" height="1267" alt="image" src="https://github.com/user-attachments/assets/48191298-7672-4c1a-a9d5-7cd441d82f83" />


## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 마이페이지 정보 수정 화면이 닉네임, 비밀번호 변경 및 실시간 유효성 검사, 모달 알림 등으로 대폭 개선되었습니다.
* **개선 사항**
  * 프로필 이미지 변경 시 사용자 정보가 즉시 반영되며, 사용자 정보가 로딩 중일 때 스피너가 표시됩니다.
  * 사용자 정보가 세션 간 유지되어 로그인 상태가 지속됩니다.
  * 마이페이지 레이아웃의 여백이 조정되어 더욱 보기 좋아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->