### PR TITLE
✨ feat: kakao login사용자 닉네임 설정

### DIFF
--- a/src/app/login/callback/kakaocallback.tsx
+++ b/src/app/login/callback/kakaocallback.tsx
@@ -62,23 +62,6 @@ export default function KakaoCallbackPage() {
 
     if (flow === 'signUp') {
       try {
-        // const kakaoToken = await fetchKakaoToken(code!, redirectUri);
-        // console.log('kakaoAccessToken:', kakaoToken);
-
-        // //액세스 토큰 → 프로필 닉네임 조회
-        // const nickname = await fetchKakaoProfile(kakaoToken);
-        // console.log('nickname:', nickname);
-
-        // //토큰 교환에 사용한 code가 아니라, 액세스 토큰(kakaoToken)
-        // const signupData = await oAuthApi.postSignUp(
-        //   { redirectUri, token: kakaoToken, nickname },
-        //   'kakao' as OAuthAppProvider,
-        // );
-        // setUser(signupData.user);
-        // localStorage.setItem('accessToken', signupData.accessToken);
-        // localStorage.setItem('refreshToken', signupData.refreshToken);
-
-        //
         const signupData = await oAuthApi.postSignUp(
           {
             redirectUri,

--- a/src/app/login/callback/kakaocallback.tsx
+++ b/src/app/login/callback/kakaocallback.tsx
@@ -1,17 +1,18 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-nested-ternary */
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import oAuthApi from '@/api/oAuth';
 import type {
   ApiError,
   OAuthAppProvider,
   OAuthRequest,
-  OAuthResponse,
 } from '@/api/types/auth';
+import Modal from '@/components/Modal/Modal';
 import { useUserStore } from '@/stores/userStore';
 
 export default function KakaoCallbackPage() {
@@ -22,6 +23,7 @@ export default function KakaoCallbackPage() {
   const isProduction = process.env.NODE_ENV === 'production';
   const APP_URL = process.env.NEXT_PUBLIC_APP_URL;
   const VERCEL_HOST = process.env.NEXT_PUBLIC_VERCEL_URL;
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const baseUrl =
     isProduction && VERCEL_HOST
       ? VERCEL_HOST.replace(/\/$/, '')
@@ -32,19 +34,11 @@ export default function KakaoCallbackPage() {
   const redirectUri = `${baseUrl}/login/callback`;
   const hasHandledRef = useRef(false);
 
-  // 1) 성공 시 상태 저장 + 리다이렉트
-  function handleSuccessfulAuth(data: OAuthResponse) {
-    setUser(data.user);
-    localStorage.setItem('accessToken', data.accessToken);
-    localStorage.setItem('refreshToken', data.refreshToken);
-    router.replace('/');
-  }
-
-  // 2) 실제 카카오 로그인/회원가입 API 호출
   async function handleAuth() {
     const body: OAuthRequest = {
       redirectUri,
       token: code!,
+      nickname: '',
     };
 
     try {
@@ -53,7 +47,11 @@ export default function KakaoCallbackPage() {
           body,
           'kakao' as OAuthAppProvider,
         );
-        return handleSuccessfulAuth(data);
+        setUser(data.user);
+        console.log(data.user);
+        localStorage.setItem('accessToken', data.accessToken);
+        localStorage.setItem('refreshToken', data.refreshToken);
+        router.replace('/');
       }
     } catch (err) {
       const apiErr = err as ApiError;
@@ -64,25 +62,48 @@ export default function KakaoCallbackPage() {
 
     if (flow === 'signUp') {
       try {
-        const data = await oAuthApi.postSignUp(
-          body,
+        // const kakaoToken = await fetchKakaoToken(code!, redirectUri);
+        // console.log('kakaoAccessToken:', kakaoToken);
+
+        // //액세스 토큰 → 프로필 닉네임 조회
+        // const nickname = await fetchKakaoProfile(kakaoToken);
+        // console.log('nickname:', nickname);
+
+        // //토큰 교환에 사용한 code가 아니라, 액세스 토큰(kakaoToken)
+        // const signupData = await oAuthApi.postSignUp(
+        //   { redirectUri, token: kakaoToken, nickname },
+        //   'kakao' as OAuthAppProvider,
+        // );
+        // setUser(signupData.user);
+        // localStorage.setItem('accessToken', signupData.accessToken);
+        // localStorage.setItem('refreshToken', signupData.refreshToken);
+
+        //
+        const signupData = await oAuthApi.postSignUp(
+          {
+            redirectUri,
+            token: code!,
+            nickname: '사용자',
+          },
           'kakao' as OAuthAppProvider,
         );
-        return handleSuccessfulAuth(data);
+        setUser(signupData.user);
+        localStorage.setItem('accessToken', signupData.accessToken);
+        localStorage.setItem('refreshToken', signupData.refreshToken);
       } catch (err) {
         const apiErr = err as ApiError;
+        console.log(apiErr.response?.data?.message);
         if (
           apiErr.response?.status === 400 &&
           apiErr.response?.data?.message === '이미 등록된 사용자입니다.'
         ) {
-          return router.replace('/login');
+          setIsModalOpen(true);
+          return;
         }
-        throw err;
       }
     }
   }
 
-  // 3) useEffect: code가 들어오면 한 번만 handleAuth 호출
   useEffect(() => {
     if (!code || hasHandledRef.current) return;
 
@@ -90,5 +111,18 @@ export default function KakaoCallbackPage() {
     void handleAuth();
   }, [code, flow, handleAuth, setUser]);
 
-  return null;
+  return (
+    <>
+      {isModalOpen && (
+        <Modal
+          message='이미 등록된 아이디 입니다.'
+          variant='onlyText'
+          onClose={() => {
+            setIsModalOpen(false);
+            router.replace('/login');
+          }}
+        />
+      )}
+    </>
+  );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -151,7 +151,7 @@ export default function Login() {
           onClose={() => {
             setIsModalOpen(false);
             if (errStatus === 404) {
-              router.replace('/signUp');
+              router.replace('/signup');
             }
           }}
         />


### PR DESCRIPTION
## 📌 변경 사항 개요


## 📝 상세 내용

**원래 원했던 닉네임 작업 흐름은,**
카카오에 인가코드or카카오토큰 을 사용해 사용자 정보를 불러온다.
-> 불러온 유저 정보에서 이름을 추출해 백엔드 회원가입 Request body에 넣는다.
-> 회원가입을 완료한다.
였는데,,
1. 카카오가 제공하는 인가코드는 1회용이다.
2. 카카오 토큰을 발급하는것도 인가코드가 필요하다.
3. 회원가입 시 인가코드가 필요하다.(카카오토큰 안됨)
**위 이유로 인해 사용자 정보를 추출해서 회원가입을 시키는게 불가능하게되었습니다..**
_(보통은 백엔드에서 처리해주는거라고 합니다..)_
## 🔗 관련 이슈

: Resolves: #206) 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항
기본으로 닉네임을  '사용자' 라고 설정하였습니다.
카카오 로그인도 이미 회원가입된 사용자면 모달띄우도록 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 이미 등록된 사용자로 인해 카카오 회원가입이 실패할 경우, 안내 모달이 표시되어 메시지를 확인할 수 있습니다. 모달을 닫으면 로그인 페이지로 이동합니다.

* **버그 수정**
  * 회원가입 실패 시 리디렉션 경로가 '/signUp'에서 '/signup'으로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->