### PR TITLE
🐛 fix: signup으로 이동하는주소 수정

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -137,7 +137,7 @@ export default function Login() {
             </Button>
             <div className='flex'>
               <p className='txt-16_M text-gray-400'>회원이 아니신가요?</p>
-              <Link className='txt-16_M text-gray-400 underline' href='/signUp'>
+              <Link className='txt-16_M text-gray-400 underline' href='/signup'>
                 회원가입하기
               </Link>
             </div>


### PR DESCRIPTION
## 📌 변경 사항 개요

로그인페이지에서 회원가입 페이지로 이동할때, 이전 주소로 되어있어 수정했습니다
signUp->signup


## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈
Resolves: #212

## 🖼️ 스크린샷(선택사항)


## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 페이지로 이동하는 링크의 경로 표기를 소문자('/signup')로 수정하여 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->