### PR TITLE
🐛 fix: 오류 모달+이동 처리

### DIFF
--- a/src/app/login/callback/kakaocallback.tsx
+++ b/src/app/login/callback/kakaocallback.tsx
@@ -24,6 +24,7 @@ export default function KakaoCallbackPage() {
   const APP_URL = process.env.NEXT_PUBLIC_APP_URL;
   const VERCEL_HOST = process.env.NEXT_PUBLIC_VERCEL_URL;
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [msg, setMsg] = useState('');
   const baseUrl =
     isProduction && VERCEL_HOST
       ? VERCEL_HOST.replace(/\/$/, '')
@@ -56,6 +57,8 @@ export default function KakaoCallbackPage() {
     } catch (err) {
       const apiErr = err as ApiError;
       if (apiErr.response?.status === 404) {
+        setIsModalOpen(true);
+        setMsg('먼저 회원가입을 해주세요.');
         return router.replace('/signUp');
       }
     }
@@ -82,6 +85,7 @@ export default function KakaoCallbackPage() {
           apiErr.response?.data?.message === '이미 등록된 사용자입니다.'
         ) {
           setIsModalOpen(true);
+          setMsg('이미 등록된 아이디 입니다.');
           return;
         }
       }
@@ -99,11 +103,15 @@ export default function KakaoCallbackPage() {
     <>
       {isModalOpen && (
         <Modal
-          message='이미 등록된 아이디 입니다.'
+          message={msg}
           variant='onlyText'
           onClose={() => {
             setIsModalOpen(false);
-            router.replace('/login');
+            if (flow === 'login') {
+              router.replace('/signUp');
+            } else {
+              router.replace('/login');
+            }
           }}
         />
       )}

--- a/src/app/login/callback/kakaocallback.tsx
+++ b/src/app/login/callback/kakaocallback.tsx
@@ -59,7 +59,6 @@ export default function KakaoCallbackPage() {
       if (apiErr.response?.status === 404) {
         setIsModalOpen(true);
         setMsg('먼저 회원가입을 해주세요.');
-        return router.replace('/signUp');
       }
     }
 


### PR DESCRIPTION
## 📌 변경 사항 개요

오류 모달+이동 처리

## 📝 상세 내용

카카오 로그인에서 회원가입이 필요한경우 모달이 뜨고 버튼을 누르면 회원가입페이지로 이동하도록，
카카오 회원가입에서 이미 등록된 사용자일 경우 모달이 뜨고 버튼을 누르면 로그인 페이지로 이동하도록 

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #) -->

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 로그인 또는 회원가입 오류 발생 시, 상황에 맞는 안내 메시지가 모달로 표시됩니다.
  * 모달을 닫으면 로그인 또는 회원가입 페이지로 자동 이동하도록 동작이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->