### PR TITLE
🐛 fix: ActivityRegisterPayload schedule > schedules 이름 변경

### DIFF
--- a/src/api/types/activities.ts
+++ b/src/api/types/activities.ts
@@ -154,7 +154,7 @@ export interface ActivityRegisterPayload {
   price: number;
   bannerImageUrl: string;
   subImageUrls: string[];
-  schedule: ActivityRegisterSchedule[];
+  schedules: ActivityRegisterSchedule[];
 }
 
 export interface ActivityRegisterSchedule {

--- a/src/app/mypage/(NoLayout)/add-activity/page.tsx
+++ b/src/app/mypage/(NoLayout)/add-activity/page.tsx
@@ -122,7 +122,7 @@ export default function Page() {
         formData.entries(),
       );
       data.price = Number(data.price);
-      data.schedule = scheduleList;
+      data.schedules = scheduleList;
       data.bannerImageUrl = bannerImages[0];
       data.subImageUrls = subImages;
 


### PR DESCRIPTION
## 📌 변경 사항 개요

ActivityRegisterPayload에 잘못 적혀있던 property 명을 수정했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

Resolves: #225

## 🖼️ 스크린샷(선택사항)

<img width="493" height="332" alt="image" src="https://github.com/user-attachments/assets/17f974fb-2a13-4ebd-86bc-023121b00217" />
<img width="492" height="731" alt="image" src="https://github.com/user-attachments/assets/4c907925-6ce4-4a71-bc09-f041aeb83064" />

## 💡 참고 사항

이제 정상적으로 post `/acitivities` 요청이 갈겁니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 활동 등록 시 일정 정보의 필드명이 `schedule`에서 `schedules`로 변경되어, 일정이 올바르게 등록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->