### PR TITLE
🐛 [bug/fix] : 체험등록시 입력한 날짜와 체험상세페이지에서 보여지는 날짜가 다른 버그 발생 

### DIFF
--- a/src/app/[activityId]/_components/MobileReserveModal.tsx
+++ b/src/app/[activityId]/_components/MobileReserveModal.tsx
@@ -6,6 +6,7 @@ import activitiesApi from '@/api/activitiesApi';
 import { useActivityDetail } from '@/app/[activityId]/_hooks/queries/useActivityDetail';
 import { useAvailableSchedule } from '@/app/[activityId]/_hooks/queries/useAvailableSchedule';
 import {
+  getKSTDateString,
   getMonthNameEnglish,
   isSameMonth,
 } from '@/app/[activityId]/_utils/activityDetailDates';
@@ -110,7 +111,6 @@ export default function MobileReserveModal({
       >
         {step === 1 && (
           <>
-            {/* 날짜 선택 */}
             <div className='txt-18_B'>날짜</div>
             <div className='my-20 flex justify-between'>
               <p className='txt-16_B'>{getMonthNameEnglish(currentDate)}</p>
@@ -144,7 +144,6 @@ export default function MobileReserveModal({
               </div>
             </div>
 
-            {/* 캘린더 */}
             <div className='grid grid-cols-7 gap-10 text-center'>
               {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => (
                 <div key={i} className='txt-16_M font-semibold'>
@@ -153,7 +152,7 @@ export default function MobileReserveModal({
               ))}
               {dates.map((date) => {
                 const isCurrent = isSameMonth(currentDate, date);
-                const formatted = date.toISOString().split('T')[0];
+                const formatted = getKSTDateString(date);
                 const isAvailable = schedules.some((s) => s.date === formatted);
                 const isSelected = selectedDate === formatted;
 
@@ -179,7 +178,6 @@ export default function MobileReserveModal({
               })}
             </div>
 
-            {/* 시간 선택 */}
             <div className='mt-24'>
               <p className='txt-16_B mb-12 text-gray-950'>예약 가능한 시간</p>
               {selectedDate ? (
@@ -222,7 +220,6 @@ export default function MobileReserveModal({
 
         {step === 2 && (
           <>
-            {/* 인원 선택 */}
             <div className='flex flex-row gap-4'>
               <button onClick={() => setStep(1)}>
                 <Icon className='h-24 w-24' icon='ArrowLeft' />
@@ -263,7 +260,6 @@ export default function MobileReserveModal({
 
         {step === 3 && (
           <>
-            {/* 가격 및 시간 요약 */}
             {price !== null && (
               <div className='mt-24'>
                 <div className='mb-12 flex justify-between'>

--- a/src/app/[activityId]/_components/ReserveCalender.tsx
+++ b/src/app/[activityId]/_components/ReserveCalender.tsx
@@ -7,6 +7,7 @@ import { ApiError } from '@/api/types/auth';
 import { useActivityDetail } from '@/app/[activityId]/_hooks/queries/useActivityDetail';
 import { useAvailableSchedule } from '@/app/[activityId]/_hooks/queries/useAvailableSchedule';
 import {
+  getKSTDateString,
   getMonthNameEnglish,
   isSameMonth,
 } from '@/app/[activityId]/_utils/activityDetailDates';
@@ -52,7 +53,7 @@ export default function ReserveCalender({
     : [];
 
   const handleDateClick = (date: Date) => {
-    const formatted = date.toISOString().split('T')[0];
+    const formatted = getKSTDateString(date);
     const isAvailable = schedules.some((s) => s.date === formatted);
     if (!isAvailable) return;
     setSelectedDate(formatted);
@@ -146,7 +147,7 @@ export default function ReserveCalender({
         ))}
         {dates.map((date) => {
           const isCurrentMonth = isSameMonth(currentDate, date);
-          const formatted = date.toISOString().split('T')[0];
+          const formatted = getKSTDateString(date);
           const isAvailable = schedules.some((s) => s.date === formatted);
           return (
             <div

--- a/src/app/[activityId]/_components/TabletReserveModal.tsx
+++ b/src/app/[activityId]/_components/TabletReserveModal.tsx
@@ -6,6 +6,7 @@ import activitiesApi from '@/api/activitiesApi';
 import { useActivityDetail } from '@/app/[activityId]/_hooks/queries/useActivityDetail';
 import { useAvailableSchedule } from '@/app/[activityId]/_hooks/queries/useAvailableSchedule';
 import {
+  getKSTDateString,
   getMonthNameEnglish,
   isSameMonth,
 } from '@/app/[activityId]/_utils/activityDetailDates';
@@ -144,7 +145,7 @@ export default function TabletReserveModal({
                   ))}
                   {dates.map((date) => {
                     const isCurrent = isSameMonth(currentDate, date);
-                    const formatted = date.toISOString().split('T')[0];
+                    const formatted = getKSTDateString(date);
                     const isAvailable = schedules.some(
                       (s) => s.date === formatted,
                     );

--- a/src/app/[activityId]/_utils/activityDetailDates.ts
+++ b/src/app/[activityId]/_utils/activityDetailDates.ts
@@ -8,3 +8,9 @@ export const getMonthNameEnglish = (date: Date): string =>
 export const isSameMonth = (base: Date, target: Date) =>
   base.getFullYear() === target.getFullYear() &&
   base.getMonth() === target.getMonth();
+
+export const getKSTDateString = (date: Date) => {
+  const offset = 9 * 60 * 60 * 1000;
+  const kstDate = new Date(date.getTime() + offset);
+  return kstDate.toISOString().split('T')[0];
+};


### PR DESCRIPTION
Resolve: #231

## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
체험예약하기 달력에서 버그가 발생했습니다.


## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

체험 등록시 체험가능일을 예를들어 월/화 로 등록했는데 체험상세에서는 화/수 로 나오는 문제점이었습니다.
KST 로 시간을 통일해서 수정했더니 정상적으로 동작합니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
#176 #231 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

##  버그발생부분 
- 달력에서 화 / 수로 보입니다.

<img width="1894" height="964" alt="image" src="https://github.com/user-attachments/assets/c8533361-1c02-414d-b256-8e6cb8975c12" />

## 해결된 UI
- 정상적으로 월 / 화로 잘 보입니다
- 월요일은 지현님이 예약테스트 하셔서 안보입니다.

<img width="1489" height="745" alt="스크린샷 2025-08-04 오후 7 28 38" src="https://github.com/user-attachments/assets/efa777b8-3f65-4b54-91ca-ce1c31bc2f8b" />



## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 날짜 선택 및 비교 시 날짜 형식이 한국 표준시(KST)에 맞춰 일관되게 표시되도록 개선되었습니다.

* **신규 기능**
  * KST(한국 표준시) 기준으로 날짜 문자열을 반환하는 기능이 추가되었습니다.

* **스타일**
  * UI 내 섹션 구분을 위한 주석이 제거되어 코드가 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->