### PR TITLE
✨ feat: 토큰만료시 재발급

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,4 +1,9 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosRequestHeaders,
+} from 'axios';
 
 const fetcher: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -7,6 +12,14 @@ const fetcher: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+const getAccessToken = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('accessToken');
+};
+
+const getRefreshToken = (): string | null =>
+  typeof window === 'undefined' ? null : localStorage.getItem('refreshToken');
 
 function isPublicRequest(method?: string, url?: string): boolean {
   if (!method || !url) return false;
@@ -24,10 +37,6 @@ function isPublicRequest(method?: string, url?: string): boolean {
   }
   return false;
 }
-const getAccessToken = (): string | null => {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem('accessToken');
-};
 fetcher.interceptors.request.use(
   (config) => {
     const { method, url } = config;
@@ -42,12 +51,49 @@ fetcher.interceptors.request.use(
   },
   (error) => Promise.reject(error),
 );
+const refreshFetcher = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  timeout: 3000,
+  headers: { 'Content-Type': 'application/json' },
+});
+
 fetcher.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      console.warn('토큰이 만료되었습니다. 재로그인이 필요합니다.');
+  (res) => res,
+  async (
+    error: AxiosError & { config?: AxiosRequestConfig & { _retry?: boolean } },
+  ) => {
+    const originalReq = error.config;
+    if (
+      error.response?.status === 401 &&
+      originalReq &&
+      !originalReq._retry &&
+      !originalReq.url?.includes('/auth/refresh')
+    ) {
+      originalReq._retry = true;
+      try {
+        const refreshToken = getRefreshToken();
+        if (!refreshToken) throw new Error('No refresh token available');
+        window.alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+
+        const { data } = await refreshFetcher.post<{
+          accessToken: string;
+          refreshToken: string;
+        }>('/auth/refresh', { refreshToken });
+
+        localStorage.setItem('accessToken', data.accessToken);
+        localStorage.setItem('refreshToken', data.refreshToken);
+
+        if (originalReq.headers) {
+          const headers = originalReq.headers as AxiosRequestHeaders;
+          headers['Authorization'] = `Bearer ${data.accessToken}`;
+        }
+        return fetcher(originalReq);
+      } catch (refreshError) {
+        console.warn('토큰 갱신 실패:', refreshError);
+        window.alert('실패했습니다.');
+      }
     }
+
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
## 📌 변경 사항 개요

Access Token 만료 시 Refresh Token으로 재발급하는 코드를 추가했습니다.

## 📝 상세 내용

401 응답을 받으면(액세스 토큰 만료)
_retry 플래그로 무한 재시도를 방지
refreshToken이 없으면 Error를 던지고
브라우저 기본 경고창으로 세션 만료 안내
별도 Axios 인스턴스(refreshFetcher)를 사용해 /auth/refresh 호출
성공 시 새 accessToken, refreshToken을 localStorage에 저장
원래 요청의 Authorization 헤더만 교체하고 재시도


## 🔗 관련 이슈


## 🖼️ 스크린샷(선택사항)



## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 만료된 인증 토큰으로 인해 발생하는 401 오류 시, 자동으로 토큰을 갱신하고 요청을 재시도하도록 개선되었습니다.
  * 세션이 만료되었을 때 사용자에게 알림이 표시됩니다.

* **기타**
  * 인증 관련 안정성이 향상되어, 로그인 세션 관리가 보다 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->